### PR TITLE
feat(conversation): add conversation package, per-turn metrics, and runner

### DIFF
--- a/src/harness_evals/__init__.py
+++ b/src/harness_evals/__init__.py
@@ -8,6 +8,14 @@ from harness_evals.baseline import (
     compare_to_baseline,
 )
 from harness_evals.catalog import CatalogEntry, catalog
+from harness_evals.conversation import (
+    ConversationGolden,
+    ConversationSimulator,
+    evaluate_conversation,
+    evaluate_conversations,
+    load_conversation_dataset,
+    save_conversation_dataset,
+)
 from harness_evals.core.eval_case import EvalCase
 from harness_evals.core.golden import Golden
 from harness_evals.core.metric import BaseMetric, Dimension, ReliabilityMetric, SafetyMetric
@@ -24,6 +32,8 @@ from harness_evals.core.sink import BaseSink
 from harness_evals.core.types import Message, ToolCall
 from harness_evals.datasets import Dataset, load_dataset, save_dataset
 from harness_evals.input_generator import InputGenerator
+from harness_evals.metrics.operational.turn_latency import TurnLatencyMetric
+from harness_evals.metrics.operational.turn_token_cost import TurnTokenCostMetric
 from harness_evals.reporting import EvalResult, HtmlReporter, HtmlSink
 from harness_evals.sinks import CsvSink, JsonSink, JUnitSink, StdoutSink
 from harness_evals.summary import MetricSummary, ScoreSummary, summarize
@@ -71,4 +81,12 @@ __all__ = [
     "ToolCall",
     "Fault",
     "FaultInjector",
+    "TurnLatencyMetric",
+    "TurnTokenCostMetric",
+    "ConversationGolden",
+    "ConversationSimulator",
+    "evaluate_conversation",
+    "evaluate_conversations",
+    "load_conversation_dataset",
+    "save_conversation_dataset",
 ]

--- a/src/harness_evals/__init__.py
+++ b/src/harness_evals/__init__.py
@@ -37,7 +37,7 @@ from harness_evals.metrics.operational.turn_token_cost import TurnTokenCostMetri
 from harness_evals.reporting import EvalResult, HtmlReporter, HtmlSink
 from harness_evals.sinks import CsvSink, JsonSink, JUnitSink, StdoutSink
 from harness_evals.summary import MetricSummary, ScoreSummary, summarize
-from harness_evals.synthesizer import Synthesizer
+from harness_evals.synthesizer import ConversationSynthesizer, ScriptedConversationSynthesizer, Synthesizer
 from harness_evals.testing import Fault, FaultInjector
 
 __all__ = [
@@ -77,6 +77,8 @@ __all__ = [
     "HtmlSink",
     "InputGenerator",
     "Synthesizer",
+    "ConversationSynthesizer",
+    "ScriptedConversationSynthesizer",
     "Message",
     "ToolCall",
     "Fault",

--- a/src/harness_evals/conversation/__init__.py
+++ b/src/harness_evals/conversation/__init__.py
@@ -1,0 +1,53 @@
+"""Multi-turn conversation evaluation: goldens, simulation, and runners."""
+
+from harness_evals.conversation.golden import ConversationGolden
+from harness_evals.conversation.runner import (
+    evaluate_conversation,
+    evaluate_conversations,
+)
+from harness_evals.conversation.simulator import ConversationSimulator
+
+__all__ = [
+    "ConversationGolden",
+    "ConversationSimulator",
+    "evaluate_conversation",
+    "evaluate_conversations",
+    "load_conversation_dataset",
+    "save_conversation_dataset",
+]
+
+
+import json
+from pathlib import Path
+
+
+def load_conversation_dataset(path: str | Path) -> list[ConversationGolden]:
+    """Load a list of ConversationGolden from a JSONL or JSON file."""
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    if p.suffix == ".jsonl":
+        records = [json.loads(line) for line in text.splitlines() if line.strip()]
+    else:
+        records = json.loads(text)
+        if not isinstance(records, list):
+            raise ValueError("JSON file must contain a list of objects")
+    return [ConversationGolden.from_dict(r) for r in records]
+
+
+def save_conversation_dataset(
+    dataset: list[ConversationGolden],
+    path: str | Path,
+    *,
+    format: str = "jsonl",
+) -> None:
+    """Save a list of ConversationGolden to a JSONL or JSON file."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if format == "jsonl":
+        lines = [json.dumps(g.to_dict(), ensure_ascii=False) for g in dataset]
+        p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    else:
+        p.write_text(
+            json.dumps([g.to_dict() for g in dataset], ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )

--- a/src/harness_evals/conversation/golden.py
+++ b/src/harness_evals/conversation/golden.py
@@ -1,0 +1,41 @@
+"""ConversationGolden — scenario-based golden for multi-turn evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from harness_evals.core.types import Message
+
+
+@dataclass
+class ConversationGolden:
+    """A scenario-based golden for multi-turn evaluation.
+
+    Unlike Golden (single input -> expected output), this describes a
+    conversation scenario that can be simulated or replayed.
+    """
+
+    scenario: str
+    expected_outcome: str
+    context: list[str] | None = None
+    turns: list[Message] | None = field(default=None)
+    max_turns: int = 10
+    user_persona: str | None = None
+    metadata: dict[str, Any] | None = field(default=None)
+    tags: dict[str, str] | None = field(default=None)
+
+    def to_dict(self) -> dict:
+        result = {}
+        for k, v in asdict(self).items():
+            if v is not None:
+                result[k] = v
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ConversationGolden:
+        mapped = dict(data)
+        if "turns" in mapped and mapped["turns"] is not None:
+            mapped["turns"] = [m if isinstance(m, Message) else Message.from_dict(m) for m in mapped["turns"]]
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in mapped.items() if k in known})

--- a/src/harness_evals/conversation/runner.py
+++ b/src/harness_evals/conversation/runner.py
@@ -1,0 +1,55 @@
+"""Convenience runners that chain conversation simulation with evaluation."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+from harness_evals.conversation.golden import ConversationGolden
+from harness_evals.conversation.simulator import ConversationSimulator
+from harness_evals.core.metric import BaseMetric
+from harness_evals.core.runner import a_evaluate
+from harness_evals.core.score import Score
+from harness_evals.core.sink import BaseSink
+from harness_evals.core.types import Message
+from harness_evals.llm.base import BaseLLM
+
+
+async def evaluate_conversation(
+    golden: ConversationGolden,
+    agent_fn: Callable[[list[Message]], Awaitable[Message]],
+    metrics: list[BaseMetric],
+    *,
+    simulator_llm: BaseLLM,
+    sinks: list[BaseSink] | None = None,
+) -> list[Score]:
+    """Simulate a conversation from a golden, then evaluate with metrics."""
+    simulator = ConversationSimulator(simulator_llm)
+    eval_case = await simulator.simulate(golden, agent_fn)
+    return await a_evaluate(eval_case, metrics, sinks)
+
+
+async def evaluate_conversations(
+    goldens: list[ConversationGolden],
+    agent_fn: Callable[[list[Message]], Awaitable[Message]],
+    metrics: list[BaseMetric],
+    *,
+    simulator_llm: BaseLLM,
+    sinks: list[BaseSink] | None = None,
+    concurrency: int = 5,
+) -> list[list[Score]]:
+    """Simulate and evaluate multiple conversation goldens concurrently."""
+    simulator = ConversationSimulator(simulator_llm, max_concurrent=concurrency)
+    eval_cases = await simulator.simulate_batch(goldens, agent_fn)
+
+    scored = await asyncio.gather(*[a_evaluate(ec, metrics) for ec in eval_cases])
+
+    if sinks:
+        for eval_case, scores in zip(eval_cases, scored, strict=True):
+            for sink in sinks:
+                sink.write(scores, eval_case)
+        for sink in sinks:
+            sink.finalize()
+            sink.shutdown()
+
+    return list(scored)

--- a/src/harness_evals/conversation/simulator.py
+++ b/src/harness_evals/conversation/simulator.py
@@ -1,0 +1,147 @@
+"""ConversationSimulator — drives multi-turn conversations between a simulated user and an agent."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+from harness_evals._async_compat import _run_async
+from harness_evals.conversation.golden import ConversationGolden
+from harness_evals.core.eval_case import EvalCase
+from harness_evals.core.types import Message
+from harness_evals.llm.base import BaseLLM
+
+_USER_PROMPT = """You are simulating a user in a conversation. Your goal is to achieve the following scenario:
+
+**Scenario**: {scenario}
+
+{persona_section}
+{context_section}
+
+**Conversation so far**:
+{history}
+
+Generate the next user message. Be natural and concise. Stay focused on achieving the scenario goal.
+Respond with ONLY the user message text, nothing else."""
+
+_STOP_PROMPT = """You are evaluating whether a conversation has achieved its expected outcome.
+
+**Expected outcome**: {expected_outcome}
+
+**Conversation**:
+{history}
+
+Has the expected outcome been fully achieved? Respond with JSON:
+{{"achieved": true/false, "reasoning": "brief explanation"}}"""
+
+_STOP_SCHEMA = {
+    "type": "object",
+    "required": ["achieved", "reasoning"],
+    "properties": {
+        "achieved": {"type": "boolean"},
+        "reasoning": {"type": "string"},
+    },
+}
+
+
+class ConversationSimulator:
+    """Drives a multi-turn conversation between a simulated user and agent-under-test."""
+
+    def __init__(self, simulator_llm: BaseLLM, *, max_concurrent: int = 5) -> None:
+        self.simulator_llm = simulator_llm
+        self.max_concurrent = max_concurrent
+
+    def simulate_sync(
+        self,
+        golden: ConversationGolden,
+        agent_fn: Callable[[list[Message]], Awaitable[Message]],
+    ) -> EvalCase:
+        return _run_async(self.simulate(golden, agent_fn))
+
+    async def simulate(
+        self,
+        golden: ConversationGolden,
+        agent_fn: Callable[[list[Message]], Awaitable[Message]],
+    ) -> EvalCase:
+        """Run one conversation and return the resulting EvalCase."""
+        if golden.turns:
+            return self._replay(golden)
+
+        history: list[Message] = []
+
+        for _ in range(golden.max_turns):
+            user_text = await self._generate_user_message(golden, history)
+            history.append(Message(role="user", content=user_text))
+
+            assistant_msg = await agent_fn(list(history))
+            history.append(assistant_msg)
+
+            if await self._should_stop(golden, history):
+                break
+
+        return self._build_eval_case(golden, history)
+
+    async def simulate_batch(
+        self,
+        goldens: list[ConversationGolden],
+        agent_fn: Callable[[list[Message]], Awaitable[Message]],
+    ) -> list[EvalCase]:
+        """Simulate multiple conversations concurrently."""
+        semaphore = asyncio.Semaphore(self.max_concurrent)
+
+        async def _run(g: ConversationGolden) -> EvalCase:
+            async with semaphore:
+                return await self.simulate(g, agent_fn)
+
+        return list(await asyncio.gather(*[_run(g) for g in goldens]))
+
+    async def _generate_user_message(self, golden: ConversationGolden, history: list[Message]) -> str:
+        persona_section = f"**Your persona**: {golden.user_persona}" if golden.user_persona else ""
+        context_section = f"**Background context**: {'; '.join(golden.context)}" if golden.context else ""
+        history_text = (
+            "\n".join(f"[{m.role}]: {m.content or ''}" for m in history)
+            if history
+            else "(conversation has not started yet)"
+        )
+
+        prompt = _USER_PROMPT.format(
+            scenario=golden.scenario,
+            persona_section=persona_section,
+            context_section=context_section,
+            history=history_text,
+        )
+        return await self.simulator_llm.generate(prompt)
+
+    async def _should_stop(self, golden: ConversationGolden, history: list[Message]) -> bool:
+        history_text = "\n".join(f"[{m.role}]: {m.content or ''}" for m in history)
+        prompt = _STOP_PROMPT.format(
+            expected_outcome=golden.expected_outcome,
+            history=history_text,
+        )
+        result = await self.simulator_llm.generate_json(prompt, _STOP_SCHEMA)
+        return bool(result.get("achieved", False))
+
+    def _replay(self, golden: ConversationGolden) -> EvalCase:
+        """Replay pre-scripted turns without simulation."""
+        assert golden.turns is not None
+        return self._build_eval_case(golden, golden.turns)
+
+    def _build_eval_case(self, golden: ConversationGolden, history: list[Message]) -> EvalCase:
+        last_assistant = ""
+        for msg in reversed(history):
+            if msg.role == "assistant":
+                last_assistant = msg.content or ""
+                break
+
+        return EvalCase(
+            input=golden.scenario,
+            output=last_assistant,
+            messages=history,
+            metadata={
+                "scenario": golden.scenario,
+                "expected_outcome": golden.expected_outcome,
+                "n_turns": len(history),
+                **(golden.metadata or {}),
+            },
+            tags=golden.tags,
+        )

--- a/src/harness_evals/core/runner.py
+++ b/src/harness_evals/core/runner.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
 
 from harness_evals.core.eval_case import EvalCase
 from harness_evals.core.golden import Golden
 from harness_evals.core.metric import BaseMetric
 from harness_evals.core.score import Score
 from harness_evals.core.sink import BaseSink
+
+if TYPE_CHECKING:
+    from harness_evals.conversation.golden import ConversationGolden
+    from harness_evals.llm.base import BaseLLM
 
 
 def _enrich_score(score: Score, metric: BaseMetric) -> None:
@@ -184,7 +189,7 @@ def evaluate_batch_metrics(
     return scores
 
 
-async def evaluate_dataset(
+async def _evaluate_dataset_single(
     goldens: list[Golden],
     agent_fn: Callable[[Golden], Awaitable[EvalCase]],
     metrics: list[BaseMetric],
@@ -192,31 +197,7 @@ async def evaluate_dataset(
     *,
     concurrency: int | None = None,
 ) -> list[list[Score]]:
-    """Run an agent on goldens, then evaluate each resulting EvalCase.
-
-    ``agent_fn`` is async because agent calls are I/O-bound. Each golden is
-    passed to ``agent_fn`` to produce an EvalCase, which is then scored
-    with ``a_evaluate()`` (the async runner) to avoid event-loop conflicts.
-
-    The ``concurrency`` semaphore gates ``agent_fn`` calls only; metric
-    evaluation (including LLM-judged metrics) runs without throttling.
-
-    Sink writes happen sequentially after all concurrent work completes
-    to avoid thread-safety issues with file-based sinks.
-
-    Args:
-        goldens: List of Golden instances.
-        agent_fn: Async function that produces an EvalCase from a Golden.
-        metrics: Metrics to evaluate.
-        sinks: Optional output sinks.
-        concurrency: Max concurrent agent calls. ``None`` = unlimited.
-
-    Raises:
-        ValueError: If ``concurrency`` is less than 1.
-    """
-    if concurrency is not None and concurrency < 1:
-        raise ValueError(f"concurrency must be >= 1, got {concurrency}")
-
+    """Internal helper: evaluate a list of single-turn Golden instances."""
     semaphore = asyncio.Semaphore(concurrency) if concurrency is not None else None
 
     async def _run_agent(golden: Golden) -> EvalCase:
@@ -236,3 +217,115 @@ async def evaluate_dataset(
 
     _finalize_sinks(sinks)
     return list(scored)
+
+
+async def _evaluate_dataset_conversation(
+    goldens: list[ConversationGolden],
+    agent_fn: Callable,
+    metrics: list[BaseMetric],
+    sinks: list[BaseSink] | None = None,
+    *,
+    concurrency: int | None = None,
+    simulator_llm: BaseLLM,
+) -> list[list[Score]]:
+    """Internal helper: evaluate a list of ConversationGolden instances."""
+    from harness_evals.conversation.simulator import ConversationSimulator
+
+    simulator = ConversationSimulator(simulator_llm, max_concurrent=concurrency or 10)
+    eval_cases = await simulator.simulate_batch(goldens, agent_fn)
+
+    scored = await asyncio.gather(*[a_evaluate(ec, metrics) for ec in eval_cases])
+
+    if sinks:
+        for eval_case, scores in zip(eval_cases, scored, strict=True):
+            for sink in sinks:
+                sink.write(scores, eval_case)
+
+    _finalize_sinks(sinks)
+    return list(scored)
+
+
+async def evaluate_dataset(
+    goldens: list[Golden] | list[ConversationGolden],
+    agent_fn: Callable,
+    metrics: list[BaseMetric],
+    sinks: list[BaseSink] | None = None,
+    *,
+    concurrency: int | None = None,
+    simulator_llm: BaseLLM | None = None,
+) -> list[list[Score]]:
+    """Run an agent on goldens, then evaluate each resulting EvalCase.
+
+    Accepts either a list of :class:`~harness_evals.core.golden.Golden`
+    (single-turn) or a list of
+    :class:`~harness_evals.conversation.golden.ConversationGolden`
+    (multi-turn). Mixed lists raise :exc:`TypeError`.
+
+    For ``ConversationGolden`` inputs, ``simulator_llm`` must be provided;
+    it drives the simulated user turns via
+    :class:`~harness_evals.conversation.simulator.ConversationSimulator`.
+
+    ``agent_fn`` is async because agent calls are I/O-bound. For
+    single-turn goldens it receives a ``Golden`` and returns an
+    ``EvalCase``; for conversation goldens it receives
+    ``list[Message]`` and returns a ``Message``.
+
+    The ``concurrency`` semaphore gates ``agent_fn`` calls only for
+    single-turn mode; for conversation mode it sets ``max_concurrent``
+    on the simulator.
+
+    Args:
+        goldens: List of ``Golden`` or ``ConversationGolden`` instances
+            (must not be mixed).
+        agent_fn: Async callable appropriate to the golden type.
+        metrics: Metrics to evaluate.
+        sinks: Optional output sinks.
+        concurrency: Max concurrent agent calls (single-turn) or
+            conversations (multi-turn). ``None`` = unlimited / default 10.
+        simulator_llm: LLM used to simulate user turns. Required when
+            ``goldens`` contains ``ConversationGolden`` instances.
+
+    Raises:
+        ValueError: If ``concurrency`` is less than 1 or if
+            ``ConversationGolden`` inputs are provided without
+            ``simulator_llm``.
+        TypeError: If ``goldens`` contains a mix of ``Golden`` and
+            ``ConversationGolden`` instances.
+    """
+    if concurrency is not None and concurrency < 1:
+        raise ValueError(f"concurrency must be >= 1, got {concurrency}")
+
+    if not goldens:
+        return []
+
+    from harness_evals.conversation.golden import ConversationGolden as _ConvGolden
+
+    types = {type(g) for g in goldens}
+    if len(types) > 1:
+        raise TypeError(
+            "evaluate_dataset() received a mixed list of Golden and ConversationGolden. "
+            "All goldens must be the same type."
+        )
+
+    if issubclass(next(iter(types)), _ConvGolden):
+        if simulator_llm is None:
+            raise ValueError(
+                "ConversationGolden inputs require a simulator_llm. "
+                "Pass simulator_llm=<BaseLLM instance> to evaluate_dataset()."
+            )
+        return await _evaluate_dataset_conversation(
+            goldens,  # type: ignore[arg-type]
+            agent_fn,
+            metrics,
+            sinks,
+            concurrency=concurrency,
+            simulator_llm=simulator_llm,
+        )
+
+    return await _evaluate_dataset_single(
+        goldens,  # type: ignore[arg-type]
+        agent_fn,
+        metrics,
+        sinks,
+        concurrency=concurrency,
+    )

--- a/src/harness_evals/core/types.py
+++ b/src/harness_evals/core/types.py
@@ -40,6 +40,9 @@ class Message:
     role: str
     content: str | None = None
     tool_calls: list[ToolCall] | None = field(default=None)
+    latency_ms: float | None = None
+    token_count: int | None = None
+    cost_usd: float | None = None
 
     def to_dict(self) -> dict:
         d: dict[str, Any] = {"role": self.role}
@@ -47,6 +50,12 @@ class Message:
             d["content"] = self.content
         if self.tool_calls is not None:
             d["tool_calls"] = [tc.to_dict() for tc in self.tool_calls]
+        if self.latency_ms is not None:
+            d["latency_ms"] = self.latency_ms
+        if self.token_count is not None:
+            d["token_count"] = self.token_count
+        if self.cost_usd is not None:
+            d["cost_usd"] = self.cost_usd
         return d
 
     @classmethod
@@ -58,4 +67,7 @@ class Message:
             role=data["role"],
             content=data.get("content"),
             tool_calls=tool_calls,
+            latency_ms=data.get("latency_ms"),
+            token_count=data.get("token_count"),
+            cost_usd=data.get("cost_usd"),
         )

--- a/src/harness_evals/metrics/__init__.py
+++ b/src/harness_evals/metrics/__init__.py
@@ -15,6 +15,10 @@ from harness_evals.metrics.conversation.coherence import ConversationCoherenceMe
 from harness_evals.metrics.conversation.conversation_completeness import (
     ConversationCompletenessMetric,
 )
+from harness_evals.metrics.conversation.conversational_geval import (
+    ConversationalGEvalMetric,
+    MultiTurnView,
+)
 from harness_evals.metrics.conversation.goal_accuracy import GoalAccuracyMetric
 from harness_evals.metrics.conversation.knowledge_retention import (
     KnowledgeRetentionMetric,
@@ -49,6 +53,8 @@ from harness_evals.metrics.operational.cost_efficiency import CostEfficiencyMetr
 from harness_evals.metrics.operational.latency import LatencyMetric
 from harness_evals.metrics.operational.retry_count import RetryCountMetric
 from harness_evals.metrics.operational.token_cost import TokenCostMetric
+from harness_evals.metrics.operational.turn_latency import TurnLatencyMetric
+from harness_evals.metrics.operational.turn_token_cost import TurnTokenCostMetric
 from harness_evals.metrics.rag.answer_correctness import AnswerCorrectnessMetric
 from harness_evals.metrics.rag.answer_relevancy import AnswerRelevancyMetric
 from harness_evals.metrics.rag.answer_similarity import AnswerSimilarityMetric
@@ -106,6 +112,8 @@ __all__ = [
     "TokenCostMetric",
     "CostEfficiencyMetric",
     "RetryCountMetric",
+    "TurnLatencyMetric",
+    "TurnTokenCostMetric",
     "OutcomeConsistencyMetric",
     "ResourceConsistencyMetric",
     "GEvalMetric",
@@ -142,6 +150,8 @@ __all__ = [
     "TopicAdherenceMetric",
     "TurnEfficiencyMetric",
     "TurnRelevancyMetric",
+    "ConversationalGEvalMetric",
+    "MultiTurnView",
     "ToolSelectionAccuracyMetric",
     "MCPTraceCompletenessMetric",
     "ListContainsMetric",

--- a/src/harness_evals/metrics/conversation/__init__.py
+++ b/src/harness_evals/metrics/conversation/__init__.py
@@ -2,6 +2,10 @@ from harness_evals.metrics.conversation.coherence import ConversationCoherenceMe
 from harness_evals.metrics.conversation.conversation_completeness import (
     ConversationCompletenessMetric,
 )
+from harness_evals.metrics.conversation.conversational_geval import (
+    ConversationalGEvalMetric,
+    MultiTurnView,
+)
 from harness_evals.metrics.conversation.goal_accuracy import GoalAccuracyMetric
 from harness_evals.metrics.conversation.knowledge_retention import (
     KnowledgeRetentionMetric,
@@ -16,9 +20,11 @@ from harness_evals.metrics.conversation.turn_relevancy import TurnRelevancyMetri
 __all__ = [
     "ConversationCoherenceMetric",
     "ConversationCompletenessMetric",
+    "ConversationalGEvalMetric",
     "ConversationResolutionMetric",
     "GoalAccuracyMetric",
     "KnowledgeRetentionMetric",
+    "MultiTurnView",
     "RoleAdherenceMetric",
     "ToolUseMetric",
     "TopicAdherenceMetric",

--- a/src/harness_evals/metrics/conversation/coherence.py
+++ b/src/harness_evals/metrics/conversation/coherence.py
@@ -23,16 +23,35 @@ Respond with JSON:
 {{"reasoning": "your analysis of conversational coherence", "score": <float between 0.0 and 1.0 where 1.0 means perfectly coherent and 0.0 means completely incoherent>}}
 """
 
+_PER_TURN_PROMPT = """You are an expert evaluator assessing the coherence of a single assistant response within a conversation.
+
+**Conversation context** (prior turns):
+{context}
+
+**Assistant response to evaluate**:
+{response}
+
+Is this response coherent with the preceding conversation? Consider:
+- Does it address what was asked?
+- Does it contradict earlier context?
+- Is the topic transition natural?
+
+Respond with JSON:
+{{"reasoning": "brief analysis of coherence for this turn", "score": <float between 0.0 and 1.0 where 1.0 means perfectly coherent>}}
+"""
+
 
 class ConversationCoherenceMetric(LLMConversationMetric):
     """LLM-judged topical coherence across conversation turns.
 
     Reads ``eval_case.messages`` — a list of ``Message`` objects representing
-    ordered turns.  Returns 0.0 if messages is missing or has fewer than
-    2 turns.
+    ordered turns. Returns per-turn breakdown in ``score.metadata["turn_scores"]``.
+    Returns 0.0 if messages is missing or has fewer than 2 turns.
     """
 
     _prompt_template = _PROMPT_TEMPLATE
+    _per_turn = True
+    _per_turn_prompt_template = _PER_TURN_PROMPT
 
     def __init__(self, llm: BaseLLM, threshold: float = 0.7, **kwargs: object) -> None:
         super().__init__(

--- a/src/harness_evals/metrics/conversation/conversational_geval.py
+++ b/src/harness_evals/metrics/conversation/conversational_geval.py
@@ -1,6 +1,8 @@
-"""Shared base class for LLM-judged conversation metrics."""
+"""ConversationalGEval — GEval adapted for multi-turn conversations with per-turn scoring."""
 
 from __future__ import annotations
+
+from enum import Enum
 
 from harness_evals._async_compat import _run_async
 from harness_evals.core.eval_case import EvalCase
@@ -17,41 +19,61 @@ _RESPONSE_SCHEMA = {
     },
 }
 
+_TURN_PROMPT = """You are an expert evaluator. Score the following assistant response in the context of a multi-turn conversation.
 
-class LLMConversationMetric(BaseMetric):
-    """Base for LLM-judged metrics that read ``eval_case.messages``.
+**Criteria**: {criteria}
 
-    Subclasses only need to set ``name`` and provide a ``_prompt_template``
-    class attribute containing a ``{conversation_text}`` placeholder.
+{steps_section}
 
-    For per-turn scoring, subclasses set ``_per_turn = True`` and provide
-    a ``_per_turn_prompt_template`` with ``{context}`` and ``{response}``
-    placeholders. The aggregate score is the mean of per-turn scores, with
-    the breakdown stored in ``score.metadata["turn_scores"]``.
+**Conversation context**:
+{context}
+
+**Assistant response to evaluate** (turn {turn_index}):
+{response}
+
+Evaluate ONLY the indicated assistant response against the criteria, considering the conversation context.
+
+Respond with JSON:
+{{"reasoning": "your analysis", "score": <float between 0.0 and 1.0>}}"""
+
+
+class MultiTurnView(str, Enum):
+    FULL_CONVERSATION = "full"
+    SLIDING_WINDOW = "window"
+
+
+class ConversationalGEvalMetric(BaseMetric):
+    """GEval adapted for multi-turn conversations with per-turn scoring.
+
+    Scores each assistant turn against the given criteria. Returns an aggregate
+    score (mean of turn scores) with per-turn breakdown in metadata.
     """
-
-    _prompt_template: str = ""
-    _per_turn: bool = False
-    _per_turn_prompt_template: str = ""
 
     def __init__(
         self,
         llm: BaseLLM,
-        threshold: float = 0.7,
+        criteria: str,
         *,
-        name: str,
+        evaluation_steps: list[str] | None = None,
+        view: MultiTurnView = MultiTurnView.FULL_CONVERSATION,
+        window_size: int = 5,
+        threshold: float = 0.7,
+        name: str = "conversational_geval",
         dimension: Dimension = Dimension.CORRECTNESS,
         **kwargs: object,
     ) -> None:
         super().__init__(name=name, dimension=dimension, threshold=threshold, **kwargs)
         self.llm = llm
+        self.criteria = criteria
+        self.evaluation_steps = evaluation_steps
+        self.view = view
+        self.window_size = window_size
 
     def measure(self, eval_case: EvalCase) -> Score:
         return _run_async(self.a_measure(eval_case))
 
     async def a_measure(self, eval_case: EvalCase) -> Score:
         messages = eval_case.messages
-
         if not messages or len(messages) < 2:
             return Score(
                 name=self.name,
@@ -60,38 +82,24 @@ class LLMConversationMetric(BaseMetric):
                 reason="messages missing or has fewer than 2 turns",
             )
 
-        if self._per_turn:
-            return await self._measure_per_turn(messages)
+        steps_section = ""
+        if self.evaluation_steps:
+            numbered = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(self.evaluation_steps))
+            steps_section = f"**Evaluation steps**:\n{numbered}"
 
-        conversation_text = "\n".join(f"[{msg.role}]: {msg.content or ''}" for msg in messages)
-        prompt = self._prompt_template.format(conversation_text=conversation_text)
-
-        result = await self.llm.generate_json(prompt, _RESPONSE_SCHEMA)
-        value = max(0.0, min(1.0, float(result.get("score", 0.0))))
-        reasoning = result.get("reasoning", "")
-
-        return Score(
-            name=self.name,
-            value=value,
-            threshold=self.threshold,
-            reason=reasoning,
-            metadata={"n_turns": len(messages)},
-        )
-
-    async def _measure_per_turn(self, messages: list) -> Score:
         turn_scores: list[dict] = []
-        assistant_idx = 0
+        assistant_turn_idx = 0
 
         for i, msg in enumerate(messages):
             if msg.role != "assistant":
                 continue
 
-            context = "\n".join(f"[{m.role}]: {m.content or ''}" for m in messages[:i])
-            if not context:
-                context = "(start of conversation)"
-
-            prompt = self._per_turn_prompt_template.format(
+            context = self._get_context(messages, i)
+            prompt = _TURN_PROMPT.format(
+                criteria=self.criteria,
+                steps_section=steps_section,
                 context=context,
+                turn_index=assistant_turn_idx + 1,
                 response=msg.content or "",
             )
 
@@ -101,13 +109,13 @@ class LLMConversationMetric(BaseMetric):
 
             turn_scores.append(
                 {
-                    "turn": assistant_idx,
+                    "turn": assistant_turn_idx,
                     "message_index": i,
                     "score": value,
                     "reasoning": reasoning,
                 }
             )
-            assistant_idx += 1
+            assistant_turn_idx += 1
 
         if not turn_scores:
             return Score(
@@ -118,6 +126,7 @@ class LLMConversationMetric(BaseMetric):
             )
 
         aggregate = sum(t["score"] for t in turn_scores) / len(turn_scores)
+
         return Score(
             name=self.name,
             value=aggregate,
@@ -129,3 +138,15 @@ class LLMConversationMetric(BaseMetric):
                 "n_assistant_turns": len(turn_scores),
             },
         )
+
+    def _get_context(self, messages: list, current_idx: int) -> str:
+        if self.view == MultiTurnView.FULL_CONVERSATION:
+            context_msgs = messages[:current_idx]
+        else:
+            start = max(0, current_idx - self.window_size * 2)
+            context_msgs = messages[start:current_idx]
+
+        if not context_msgs:
+            return "(start of conversation)"
+
+        return "\n".join(f"[{m.role}]: {m.content or ''}" for m in context_msgs)

--- a/src/harness_evals/metrics/conversation/knowledge_retention.py
+++ b/src/harness_evals/metrics/conversation/knowledge_retention.py
@@ -25,16 +25,34 @@ Respond with JSON:
 {{"reasoning": "your analysis of knowledge retention, citing any instances of forgetting or contradiction", "score": <float between 0.0 and 1.0 where 1.0 means perfect retention and 0.0 means complete forgetting>}}
 """
 
+_PER_TURN_PROMPT = """You are an expert evaluator assessing knowledge retention in a single assistant response.
+
+**Conversation context** (prior turns):
+{context}
+
+**Assistant response to evaluate**:
+{response}
+
+Does this response demonstrate retention of facts, preferences, and details from earlier turns?
+Penalize if it asks for already-provided info, contradicts earlier context, or ignores established facts.
+
+Respond with JSON:
+{{"reasoning": "brief analysis of retention in this turn", "score": <float between 0.0 and 1.0 where 1.0 means perfect retention>}}
+"""
+
 
 class KnowledgeRetentionMetric(LLMConversationMetric):
     """LLM-judged evaluation of knowledge retention across conversation turns.
 
     Reads ``eval_case.messages`` and evaluates whether the assistant
-    remembers and uses information from earlier turns. Returns 0.0
+    remembers and uses information from earlier turns. Returns per-turn
+    breakdown in ``score.metadata["turn_scores"]``. Returns 0.0
     if messages is missing or has fewer than 2 turns.
     """
 
     _prompt_template = _PROMPT_TEMPLATE
+    _per_turn = True
+    _per_turn_prompt_template = _PER_TURN_PROMPT
 
     def __init__(self, llm: BaseLLM, threshold: float = 0.7, **kwargs: object) -> None:
         super().__init__(

--- a/src/harness_evals/metrics/conversation/turn_relevancy.py
+++ b/src/harness_evals/metrics/conversation/turn_relevancy.py
@@ -26,16 +26,34 @@ Respond with JSON:
 {{"reasoning": "your analysis of per-turn relevancy, citing any irrelevant responses", "score": <float between 0.0 and 1.0 where 1.0 means all responses are relevant and 0.0 means none are>}}
 """
 
+_PER_TURN_PROMPT = """You are an expert evaluator assessing the relevancy of a single assistant response.
+
+**Conversation context**:
+{context}
+
+**Assistant response to evaluate**:
+{response}
+
+Is this response relevant to the immediately preceding user message and broader context?
+Note: Vague responses to vague inputs (such as greetings) do NOT count as irrelevant.
+
+Respond with JSON:
+{{"reasoning": "brief analysis of relevancy", "score": <float between 0.0 and 1.0 where 1.0 means fully relevant>}}
+"""
+
 
 class TurnRelevancyMetric(LLMConversationMetric):
     """LLM-judged evaluation of per-turn relevancy in a conversation.
 
     Reads ``eval_case.messages`` and evaluates whether each assistant
-    response is relevant to the preceding context. Returns 0.0 if
+    response is relevant to the preceding context. Returns per-turn
+    breakdown in ``score.metadata["turn_scores"]``. Returns 0.0 if
     messages is missing or has fewer than 2 turns.
     """
 
     _prompt_template = _PROMPT_TEMPLATE
+    _per_turn = True
+    _per_turn_prompt_template = _PER_TURN_PROMPT
 
     def __init__(self, llm: BaseLLM, threshold: float = 0.7, **kwargs: object) -> None:
         super().__init__(llm=llm, threshold=threshold, name="turn_relevancy", dimension=Dimension.CORRECTNESS, **kwargs)

--- a/src/harness_evals/metrics/operational/__init__.py
+++ b/src/harness_evals/metrics/operational/__init__.py
@@ -2,5 +2,14 @@ from harness_evals.metrics.operational.cost_efficiency import CostEfficiencyMetr
 from harness_evals.metrics.operational.latency import LatencyMetric
 from harness_evals.metrics.operational.retry_count import RetryCountMetric
 from harness_evals.metrics.operational.token_cost import TokenCostMetric
+from harness_evals.metrics.operational.turn_latency import TurnLatencyMetric
+from harness_evals.metrics.operational.turn_token_cost import TurnTokenCostMetric
 
-__all__ = ["LatencyMetric", "TokenCostMetric", "CostEfficiencyMetric", "RetryCountMetric"]
+__all__ = [
+    "LatencyMetric",
+    "TokenCostMetric",
+    "CostEfficiencyMetric",
+    "RetryCountMetric",
+    "TurnLatencyMetric",
+    "TurnTokenCostMetric",
+]

--- a/src/harness_evals/metrics/operational/turn_latency.py
+++ b/src/harness_evals/metrics/operational/turn_latency.py
@@ -1,0 +1,70 @@
+"""TurnLatencyMetric — scores average per-turn latency across assistant messages."""
+
+from __future__ import annotations
+
+from harness_evals.core.eval_case import EvalCase
+from harness_evals.core.metric import BaseMetric, Dimension
+from harness_evals.core.score import Score
+
+
+class TurnLatencyMetric(BaseMetric):
+    """Score based on per-turn latency from Message.latency_ms.
+
+    Reads latency_ms from each assistant Message. Scores each turn as
+    max(0, 1 - latency_ms / max_ms_per_turn), then returns the mean.
+    Turns with no latency_ms are skipped. Returns 0.0 if no turns have data.
+    """
+
+    def __init__(
+        self,
+        max_ms_per_turn: float = 3000,
+        threshold: float = 0.5,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(
+            name="turn_latency",
+            dimension=Dimension.PERFORMANCE,
+            threshold=threshold,
+            **kwargs,
+        )
+        self.max_ms_per_turn = max_ms_per_turn
+
+    def measure(self, eval_case: EvalCase) -> Score:
+        messages = eval_case.messages
+        if not messages:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason="no messages provided",
+            )
+
+        latencies = [
+            msg.latency_ms
+            for msg in messages
+            if msg.role == "assistant" and msg.latency_ms is not None
+        ]
+
+        if not latencies:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason="no latency data on assistant turns",
+            )
+
+        scores = [max(0.0, 1.0 - lat / self.max_ms_per_turn) for lat in latencies]
+        mean_score = sum(scores) / len(scores)
+        mean_latency = sum(latencies) / len(latencies)
+
+        return Score(
+            name=self.name,
+            value=mean_score,
+            threshold=self.threshold,
+            metadata={
+                "turn_latencies": latencies,
+                "mean_latency_ms": mean_latency,
+                "max_ms_per_turn": self.max_ms_per_turn,
+                "n_turns_scored": len(latencies),
+            },
+        )

--- a/src/harness_evals/metrics/operational/turn_latency.py
+++ b/src/harness_evals/metrics/operational/turn_latency.py
@@ -39,11 +39,12 @@ class TurnLatencyMetric(BaseMetric):
                 reason="no messages provided",
             )
 
-        latencies = [
-            msg.latency_ms
-            for msg in messages
-            if msg.role == "assistant" and msg.latency_ms is not None
-        ]
+        latencies = []
+        for msg in messages:
+            if msg.role == "assistant" and msg.latency_ms is not None:
+                if msg.latency_ms < 0:
+                    continue
+                latencies.append(msg.latency_ms)
 
         if not latencies:
             return Score(

--- a/src/harness_evals/metrics/operational/turn_token_cost.py
+++ b/src/harness_evals/metrics/operational/turn_token_cost.py
@@ -1,0 +1,69 @@
+"""TurnTokenCostMetric — scores average per-turn token usage across assistant messages."""
+
+from __future__ import annotations
+
+from harness_evals.core.eval_case import EvalCase
+from harness_evals.core.metric import BaseMetric, Dimension
+from harness_evals.core.score import Score
+
+
+class TurnTokenCostMetric(BaseMetric):
+    """Score based on per-turn token count from Message.token_count.
+
+    Reads token_count from each assistant Message. Scores each turn as
+    max(0, 1 - token_count / max_tokens_per_turn), then returns the mean.
+    Turns with no token_count are skipped. Returns 0.0 if no turns have data.
+    """
+
+    def __init__(
+        self,
+        max_tokens_per_turn: int = 2000,
+        threshold: float = 0.5,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(
+            name="turn_token_cost",
+            dimension=Dimension.PERFORMANCE,
+            threshold=threshold,
+            **kwargs,
+        )
+        self.max_tokens_per_turn = max_tokens_per_turn
+
+    def measure(self, eval_case: EvalCase) -> Score:
+        messages = eval_case.messages
+        if not messages:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason="no messages provided",
+            )
+
+        token_counts = [
+            msg.token_count
+            for msg in messages
+            if msg.role == "assistant" and msg.token_count is not None
+        ]
+
+        if not token_counts:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason="no token count data on assistant turns",
+            )
+
+        scores = [max(0.0, 1.0 - tc / self.max_tokens_per_turn) for tc in token_counts]
+        mean_score = sum(scores) / len(scores)
+
+        return Score(
+            name=self.name,
+            value=mean_score,
+            threshold=self.threshold,
+            metadata={
+                "turn_token_counts": token_counts,
+                "total_tokens": sum(token_counts),
+                "max_tokens_per_turn": self.max_tokens_per_turn,
+                "n_turns_scored": len(token_counts),
+            },
+        )

--- a/src/harness_evals/metrics/operational/turn_token_cost.py
+++ b/src/harness_evals/metrics/operational/turn_token_cost.py
@@ -39,11 +39,12 @@ class TurnTokenCostMetric(BaseMetric):
                 reason="no messages provided",
             )
 
-        token_counts = [
-            msg.token_count
-            for msg in messages
-            if msg.role == "assistant" and msg.token_count is not None
-        ]
+        token_counts = []
+        for msg in messages:
+            if msg.role == "assistant" and msg.token_count is not None:
+                if msg.token_count < 0:
+                    continue
+                token_counts.append(msg.token_count)
 
         if not token_counts:
             return Score(
@@ -55,6 +56,7 @@ class TurnTokenCostMetric(BaseMetric):
 
         scores = [max(0.0, 1.0 - tc / self.max_tokens_per_turn) for tc in token_counts]
         mean_score = sum(scores) / len(scores)
+        mean_token_count = sum(token_counts) / len(token_counts)
 
         return Score(
             name=self.name,
@@ -62,7 +64,7 @@ class TurnTokenCostMetric(BaseMetric):
             threshold=self.threshold,
             metadata={
                 "turn_token_counts": token_counts,
-                "total_tokens": sum(token_counts),
+                "mean_token_count": mean_token_count,
                 "max_tokens_per_turn": self.max_tokens_per_turn,
                 "n_turns_scored": len(token_counts),
             },

--- a/src/harness_evals/synthesizer/__init__.py
+++ b/src/harness_evals/synthesizer/__init__.py
@@ -6,6 +6,7 @@ from harness_evals._async_compat import _run_async
 from harness_evals.datasets import Dataset
 from harness_evals.llm.base import BaseLLM
 from harness_evals.synthesizer.base import BaseSynthesizer
+from harness_evals.synthesizer.conversation import ConversationSynthesizer, ScriptedConversationSynthesizer
 from harness_evals.synthesizer.extraction import ExtractionSynthesizer
 from harness_evals.synthesizer.qa import QASynthesizer
 from harness_evals.synthesizer.structured import StructuredOutputSynthesizer
@@ -16,6 +17,8 @@ _GENERATORS: dict[str, type[BaseSynthesizer]] = {
     "summarization": SummarizationSynthesizer,
     "extraction": ExtractionSynthesizer,
     "structured_output": StructuredOutputSynthesizer,
+    "conversation": ConversationSynthesizer,
+    "conversation_scripted": ScriptedConversationSynthesizer,
 }
 
 
@@ -54,19 +57,23 @@ class Synthesizer:
         n: int = 20,
         task_type: str = "qa",
         difficulty: str = "mixed",
-    ) -> Dataset:
+    ) -> list:
         """Generate *n* goldens from *documents* for the given *task_type*.
 
         Args:
             documents: Source document strings to generate from.
             n: Number of goldens to generate.
             task_type: One of ``"qa"``, ``"summarization"``,
-                ``"extraction"``, ``"structured_output"``.
+                ``"extraction"``, ``"structured_output"``,
+                ``"conversation"``, ``"conversation_scripted"``.
+                Conversation task types return ``list[ConversationGolden]``
+                instead of ``Dataset`` (``list[Golden]``).
             difficulty: One of ``"easy"``, ``"medium"``, ``"hard"``,
                 ``"mixed"``.
 
         Returns:
-            A ``Dataset`` (``list[Golden]``).
+            A ``Dataset`` (``list[Golden]``) for standard task types, or
+            ``list[ConversationGolden]`` for conversation task types.
         """
         if task_type not in _GENERATORS:
             raise ValueError(f"Unknown task_type {task_type!r}. Choose from: {', '.join(sorted(_GENERATORS))}")
@@ -96,4 +103,6 @@ __all__ = [
     "SummarizationSynthesizer",
     "ExtractionSynthesizer",
     "StructuredOutputSynthesizer",
+    "ConversationSynthesizer",
+    "ScriptedConversationSynthesizer",
 ]

--- a/src/harness_evals/synthesizer/conversation.py
+++ b/src/harness_evals/synthesizer/conversation.py
@@ -97,6 +97,16 @@ _SCRIPTED_SCHEMA: dict = {
 }
 
 
+def _deduplicate_by_scenario(goldens: list) -> list:
+    seen: set[str] = set()
+    result = []
+    for g in goldens:
+        if g.scenario not in seen:
+            seen.add(g.scenario)
+            result.append(g)
+    return result
+
+
 class ConversationSynthesizer(BaseSynthesizer):
     """Generate scenario-based ConversationGolden datasets from source documents."""
 
@@ -137,16 +147,8 @@ class ConversationSynthesizer(BaseSynthesizer):
         return goldens  # type: ignore[return-value]
 
     @staticmethod
-    def _deduplicate(goldens: list[Golden]) -> list[Golden]:  # type: ignore[override]
-        """Remove ConversationGoldens with duplicate ``scenario`` values."""
-        seen: set[str] = set()
-        result: list[Golden] = []
-        for g in goldens:
-            key = g.scenario if isinstance(g, ConversationGolden) else str(g)  # type: ignore[union-attr]
-            if key not in seen:
-                seen.add(key)
-                result.append(g)
-        return result
+    def _deduplicate(goldens: list) -> list:  # type: ignore[override]
+        return _deduplicate_by_scenario(goldens)
 
 
 class ScriptedConversationSynthesizer(BaseSynthesizer):
@@ -196,13 +198,5 @@ class ScriptedConversationSynthesizer(BaseSynthesizer):
         return goldens  # type: ignore[return-value]
 
     @staticmethod
-    def _deduplicate(goldens: list[Golden]) -> list[Golden]:  # type: ignore[override]
-        """Remove ConversationGoldens with duplicate ``scenario`` values."""
-        seen: set[str] = set()
-        result: list[Golden] = []
-        for g in goldens:
-            key = g.scenario if isinstance(g, ConversationGolden) else str(g)  # type: ignore[union-attr]
-            if key not in seen:
-                seen.add(key)
-                result.append(g)
-        return result
+    def _deduplicate(goldens: list) -> list:  # type: ignore[override]
+        return _deduplicate_by_scenario(goldens)

--- a/src/harness_evals/synthesizer/conversation.py
+++ b/src/harness_evals/synthesizer/conversation.py
@@ -1,0 +1,208 @@
+"""Conversation synthesizers — generate ConversationGolden datasets from documents."""
+
+from __future__ import annotations
+
+from harness_evals.conversation.golden import ConversationGolden
+from harness_evals.core.golden import Golden
+from harness_evals.core.types import Message
+from harness_evals.synthesizer.base import BaseSynthesizer
+
+__all__ = ["ConversationSynthesizer", "ScriptedConversationSynthesizer"]
+
+_SCENARIO_PROMPT_TEMPLATE = """\
+You are an expert at creating evaluation datasets for conversational AI systems.
+Given the following document, generate exactly {n} conversation scenarios.
+
+**Difficulty level**: {difficulty}
+- easy: Simple, single-topic conversations.
+- medium: Conversations requiring understanding of multiple concepts.
+- hard: Complex conversations requiring reasoning across the full document.
+- mixed: A mix of easy, medium, and hard scenarios.
+
+**Document**:
+{chunk}
+
+Generate exactly {n} conversation scenarios. Each scenario should describe a realistic
+user-agent interaction that can be evaluated against the document.
+
+Respond with JSON:
+{{"scenarios": [{{"scenario": "description of the scenario", "expected_outcome": "what a successful outcome looks like", "user_persona": "description of the user (optional)"}}]}}
+"""
+
+_SCRIPTED_PROMPT_TEMPLATE = """\
+You are an expert at creating evaluation datasets for conversational AI systems.
+Given the following document, generate exactly {n} scripted multi-turn conversations.
+
+**Difficulty level**: {difficulty}
+- easy: Short conversations with simple, direct exchanges.
+- medium: Conversations with a few turns covering multiple topics.
+- hard: Long conversations requiring complex reasoning across the full document.
+- mixed: A mix of easy, medium, and hard conversations.
+
+**Document**:
+{chunk}
+
+Generate exactly {n} scripted conversations with realistic turn-by-turn exchanges.
+
+Respond with JSON:
+{{"conversations": [{{"scenario": "description", "expected_outcome": "what success looks like", "turns": [{{"role": "user|assistant", "content": "message content"}}]}}]}}
+"""
+
+_SCENARIO_SCHEMA: dict = {
+    "type": "object",
+    "required": ["scenarios"],
+    "properties": {
+        "scenarios": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["scenario", "expected_outcome"],
+                "properties": {
+                    "scenario": {"type": "string"},
+                    "expected_outcome": {"type": "string"},
+                    "user_persona": {"type": "string"},
+                },
+            },
+        }
+    },
+}
+
+_SCRIPTED_SCHEMA: dict = {
+    "type": "object",
+    "required": ["conversations"],
+    "properties": {
+        "conversations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["scenario", "expected_outcome", "turns"],
+                "properties": {
+                    "scenario": {"type": "string"},
+                    "expected_outcome": {"type": "string"},
+                    "turns": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["role", "content"],
+                            "properties": {
+                                "role": {"type": "string"},
+                                "content": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    },
+}
+
+
+class ConversationSynthesizer(BaseSynthesizer):
+    """Generate scenario-based ConversationGolden datasets from source documents."""
+
+    task_type = "conversation"
+
+    def _build_prompt(self, chunk: str, n: int, difficulty: str) -> str:
+        return _SCENARIO_PROMPT_TEMPLATE.format(n=n, difficulty=difficulty, chunk=chunk)
+
+    def _response_schema(self) -> dict:
+        return _SCENARIO_SCHEMA
+
+    def _parse_response(
+        self,
+        response: dict,
+        doc_index: int,
+        difficulty: str,
+    ) -> list[Golden]:  # type: ignore[override]
+        scenarios = response.get("scenarios", [])
+        goldens: list[ConversationGolden] = []
+        for item in scenarios:
+            scenario = item.get("scenario", "")
+            expected_outcome = item.get("expected_outcome", "")
+            if not scenario or not expected_outcome:
+                continue
+            user_persona = item.get("user_persona") or None
+            goldens.append(
+                ConversationGolden(
+                    scenario=scenario,
+                    expected_outcome=expected_outcome,
+                    user_persona=user_persona,
+                    metadata={
+                        "task_type": self.task_type,
+                        "difficulty": difficulty,
+                        "source_document_index": doc_index,
+                    },
+                )
+            )
+        return goldens  # type: ignore[return-value]
+
+    @staticmethod
+    def _deduplicate(goldens: list[Golden]) -> list[Golden]:  # type: ignore[override]
+        """Remove ConversationGoldens with duplicate ``scenario`` values."""
+        seen: set[str] = set()
+        result: list[Golden] = []
+        for g in goldens:
+            key = g.scenario if isinstance(g, ConversationGolden) else str(g)  # type: ignore[union-attr]
+            if key not in seen:
+                seen.add(key)
+                result.append(g)
+        return result
+
+
+class ScriptedConversationSynthesizer(BaseSynthesizer):
+    """Generate scripted multi-turn ConversationGolden datasets from source documents."""
+
+    task_type = "conversation_scripted"
+
+    def _build_prompt(self, chunk: str, n: int, difficulty: str) -> str:
+        return _SCRIPTED_PROMPT_TEMPLATE.format(n=n, difficulty=difficulty, chunk=chunk)
+
+    def _response_schema(self) -> dict:
+        return _SCRIPTED_SCHEMA
+
+    def _parse_response(
+        self,
+        response: dict,
+        doc_index: int,
+        difficulty: str,
+    ) -> list[Golden]:  # type: ignore[override]
+        conversations = response.get("conversations", [])
+        goldens: list[ConversationGolden] = []
+        for item in conversations:
+            scenario = item.get("scenario", "")
+            expected_outcome = item.get("expected_outcome", "")
+            if not scenario or not expected_outcome:
+                continue
+            raw_turns = item.get("turns", [])
+            turns: list[Message] = []
+            for turn in raw_turns:
+                role = turn.get("role")
+                content = turn.get("content", "")
+                if not role:
+                    continue
+                turns.append(Message(role=role, content=content))
+            goldens.append(
+                ConversationGolden(
+                    scenario=scenario,
+                    expected_outcome=expected_outcome,
+                    turns=turns if turns else None,
+                    metadata={
+                        "task_type": self.task_type,
+                        "difficulty": difficulty,
+                        "source_document_index": doc_index,
+                    },
+                )
+            )
+        return goldens  # type: ignore[return-value]
+
+    @staticmethod
+    def _deduplicate(goldens: list[Golden]) -> list[Golden]:  # type: ignore[override]
+        """Remove ConversationGoldens with duplicate ``scenario`` values."""
+        seen: set[str] = set()
+        result: list[Golden] = []
+        for g in goldens:
+            key = g.scenario if isinstance(g, ConversationGolden) else str(g)  # type: ignore[union-attr]
+            if key not in seen:
+                seen.add(key)
+                result.append(g)
+        return result

--- a/tests/conversation/test_golden.py
+++ b/tests/conversation/test_golden.py
@@ -1,0 +1,138 @@
+"""Tests for ConversationGolden and dataset I/O."""
+
+import pytest
+
+from harness_evals.conversation import (
+    ConversationGolden,
+    load_conversation_dataset,
+    save_conversation_dataset,
+)
+from harness_evals.core.types import Message
+
+
+@pytest.mark.unit
+class TestConversationGolden:
+    def test_basic_creation(self):
+        g = ConversationGolden(
+            scenario="User asks about refund policy",
+            expected_outcome="Agent provides refund timeline and process",
+        )
+        assert g.scenario == "User asks about refund policy"
+        assert g.max_turns == 10
+        assert g.turns is None
+
+    def test_with_turns(self):
+        turns = [
+            Message(role="user", content="How do I get a refund?"),
+            Message(role="assistant", content="You can request a refund within 30 days."),
+        ]
+        g = ConversationGolden(
+            scenario="Refund inquiry",
+            expected_outcome="Refund process explained",
+            turns=turns,
+        )
+        assert len(g.turns) == 2
+        assert g.turns[0].role == "user"
+
+    def test_to_dict(self):
+        g = ConversationGolden(
+            scenario="Test scenario",
+            expected_outcome="Test outcome",
+            max_turns=5,
+            user_persona="Frustrated customer",
+        )
+        d = g.to_dict()
+        assert d["scenario"] == "Test scenario"
+        assert d["max_turns"] == 5
+        assert "turns" not in d  # None fields excluded
+
+    def test_to_dict_with_turns(self):
+        g = ConversationGolden(
+            scenario="Test",
+            expected_outcome="Outcome",
+            turns=[Message(role="user", content="hi")],
+        )
+        d = g.to_dict()
+        assert d["turns"][0]["role"] == "user"
+        assert d["turns"][0]["content"] == "hi"
+
+    def test_from_dict(self):
+        data = {
+            "scenario": "Test",
+            "expected_outcome": "Done",
+            "max_turns": 8,
+            "context": ["Background info"],
+        }
+        g = ConversationGolden.from_dict(data)
+        assert g.scenario == "Test"
+        assert g.max_turns == 8
+        assert g.context == ["Background info"]
+
+    def test_from_dict_with_turns(self):
+        data = {
+            "scenario": "Test",
+            "expected_outcome": "Done",
+            "turns": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"},
+            ],
+        }
+        g = ConversationGolden.from_dict(data)
+        assert len(g.turns) == 2
+        assert isinstance(g.turns[0], Message)
+        assert g.turns[1].content == "hi there"
+
+    def test_from_dict_ignores_unknown_fields(self):
+        data = {
+            "scenario": "Test",
+            "expected_outcome": "Done",
+            "unknown_field": "ignored",
+        }
+        g = ConversationGolden.from_dict(data)
+        assert g.scenario == "Test"
+
+    def test_roundtrip(self):
+        original = ConversationGolden(
+            scenario="Roundtrip test",
+            expected_outcome="Passes",
+            context=["ctx1", "ctx2"],
+            max_turns=7,
+            user_persona="Developer",
+            metadata={"key": "value"},
+            tags={"env": "test"},
+        )
+        restored = ConversationGolden.from_dict(original.to_dict())
+        assert restored.scenario == original.scenario
+        assert restored.max_turns == original.max_turns
+        assert restored.metadata == original.metadata
+
+
+@pytest.mark.unit
+class TestConversationDatasetIO:
+    def test_save_and_load_jsonl(self, tmp_path):
+        dataset = [
+            ConversationGolden(scenario="S1", expected_outcome="O1"),
+            ConversationGolden(scenario="S2", expected_outcome="O2", max_turns=5),
+        ]
+        path = tmp_path / "test.jsonl"
+        save_conversation_dataset(dataset, path)
+        loaded = load_conversation_dataset(path)
+        assert len(loaded) == 2
+        assert loaded[0].scenario == "S1"
+        assert loaded[1].max_turns == 5
+
+    def test_save_and_load_json(self, tmp_path):
+        dataset = [
+            ConversationGolden(scenario="S1", expected_outcome="O1"),
+        ]
+        path = tmp_path / "test.json"
+        save_conversation_dataset(dataset, path, format="json")
+        loaded = load_conversation_dataset(path)
+        assert len(loaded) == 1
+        assert loaded[0].scenario == "S1"
+
+    def test_load_invalid_json_raises(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text('{"not": "a list"}')
+        with pytest.raises(ValueError, match="list"):
+            load_conversation_dataset(path)

--- a/tests/conversation/test_simulator.py
+++ b/tests/conversation/test_simulator.py
@@ -1,0 +1,151 @@
+"""Tests for ConversationSimulator."""
+
+import pytest
+
+from harness_evals.conversation import ConversationGolden, ConversationSimulator
+from harness_evals.core.types import Message
+from tests.conftest import MockLLM
+
+
+class SimulatorMockLLM(MockLLM):
+    """Mock LLM that returns user messages via generate() and stop checks via generate_json()."""
+
+    def __init__(self, user_messages: list[str], stop_after: int = 2):
+        self._user_messages = user_messages
+        self._user_idx = 0
+        self._json_call_count = 0
+        self._stop_after = stop_after
+        super().__init__()
+
+    async def generate(self, prompt: str, **kwargs) -> str:
+        if self._user_idx < len(self._user_messages):
+            msg = self._user_messages[self._user_idx]
+            self._user_idx += 1
+            return msg
+        return "Thank you, that's all."
+
+    async def generate_json(self, prompt: str, schema: dict, **kwargs) -> dict:
+        self._json_call_count += 1
+        achieved = self._json_call_count >= self._stop_after
+        return {"achieved": achieved, "reasoning": "test"}
+
+
+@pytest.mark.unit
+class TestConversationSimulator:
+    async def test_basic_simulation(self):
+        llm = SimulatorMockLLM(
+            user_messages=["What is your refund policy?", "How long does it take?"],
+            stop_after=2,
+        )
+
+        async def agent_fn(messages: list[Message]) -> Message:
+            return Message(role="assistant", content=f"Response to turn {len(messages)}")
+
+        golden = ConversationGolden(
+            scenario="Ask about refund policy",
+            expected_outcome="Agent explains refund process",
+        )
+
+        simulator = ConversationSimulator(simulator_llm=llm)
+        result = await simulator.simulate(golden, agent_fn)
+
+        assert result.messages is not None
+        assert len(result.messages) >= 4  # At least 2 user + 2 assistant turns
+        assert result.input == "Ask about refund policy"
+        assert result.metadata["scenario"] == "Ask about refund policy"
+        assert result.metadata["expected_outcome"] == "Agent explains refund process"
+
+    async def test_max_turns_cap(self):
+        llm = SimulatorMockLLM(
+            user_messages=["msg"] * 20,
+            stop_after=100,  # Never stops naturally
+        )
+
+        async def agent_fn(messages: list[Message]) -> Message:
+            return Message(role="assistant", content="response")
+
+        golden = ConversationGolden(
+            scenario="Test",
+            expected_outcome="Outcome",
+            max_turns=4,  # Cap at 4 turns total (2 exchanges)
+        )
+
+        simulator = ConversationSimulator(simulator_llm=llm)
+        result = await simulator.simulate(golden, agent_fn)
+
+        assert len(result.messages) <= 8  # max_turns iterations, each adds 2 messages
+
+    async def test_replay_mode(self):
+        llm = MockLLM()  # Should not be called
+        turns = [
+            Message(role="user", content="Hello"),
+            Message(role="assistant", content="Hi there!"),
+            Message(role="user", content="How are you?"),
+            Message(role="assistant", content="I'm doing well, thanks!"),
+        ]
+
+        golden = ConversationGolden(
+            scenario="Greeting",
+            expected_outcome="Polite exchange",
+            turns=turns,
+        )
+
+        simulator = ConversationSimulator(simulator_llm=llm)
+        result = await simulator.simulate(golden, agent_fn=lambda x: None)
+
+        assert result.messages == turns
+        assert result.output == "I'm doing well, thanks!"
+        assert result.metadata["n_turns"] == 4
+
+    async def test_output_is_last_assistant_message(self):
+        llm = SimulatorMockLLM(user_messages=["question"], stop_after=1)
+
+        async def agent_fn(messages: list[Message]) -> Message:
+            return Message(role="assistant", content="final answer")
+
+        golden = ConversationGolden(
+            scenario="Test",
+            expected_outcome="Done",
+        )
+
+        simulator = ConversationSimulator(simulator_llm=llm)
+        result = await simulator.simulate(golden, agent_fn)
+
+        assert result.output == "final answer"
+
+    async def test_simulate_batch(self):
+        llm = SimulatorMockLLM(
+            user_messages=["q1", "q2", "q3", "q4"],
+            stop_after=1,
+        )
+
+        async def agent_fn(messages: list[Message]) -> Message:
+            return Message(role="assistant", content="answer")
+
+        goldens = [ConversationGolden(scenario=f"S{i}", expected_outcome=f"O{i}") for i in range(3)]
+
+        simulator = ConversationSimulator(simulator_llm=llm, max_concurrent=2)
+        results = await simulator.simulate_batch(goldens, agent_fn)
+
+        assert len(results) == 3
+        for r in results:
+            assert r.messages is not None
+
+    async def test_metadata_from_golden(self):
+        llm = SimulatorMockLLM(user_messages=["hi"], stop_after=1)
+
+        async def agent_fn(messages: list[Message]) -> Message:
+            return Message(role="assistant", content="hello")
+
+        golden = ConversationGolden(
+            scenario="Test",
+            expected_outcome="Done",
+            metadata={"custom_key": "custom_value"},
+            tags={"env": "test"},
+        )
+
+        simulator = ConversationSimulator(simulator_llm=llm)
+        result = await simulator.simulate(golden, agent_fn)
+
+        assert result.metadata["custom_key"] == "custom_value"
+        assert result.tags == {"env": "test"}

--- a/tests/metrics/test_conversational_geval.py
+++ b/tests/metrics/test_conversational_geval.py
@@ -1,0 +1,147 @@
+"""Tests for ConversationalGEvalMetric."""
+
+import pytest
+
+from harness_evals.core.eval_case import EvalCase
+from harness_evals.core.types import Message
+from harness_evals.metrics.conversation.conversational_geval import (
+    ConversationalGEvalMetric,
+    MultiTurnView,
+)
+from tests.conftest import MockLLM
+
+MESSAGES = [
+    Message(role="user", content="What is Python?"),
+    Message(role="assistant", content="Python is a programming language."),
+    Message(role="user", content="What about its typing?"),
+    Message(role="assistant", content="Python supports dynamic and optional static typing."),
+]
+
+
+@pytest.mark.unit
+class TestConversationalGEval:
+    async def test_basic_scoring(self):
+        llm = MockLLM(default={"reasoning": "Good response", "score": 0.9})
+        metric = ConversationalGEvalMetric(
+            llm=llm,
+            criteria="Is the response accurate and helpful?",
+        )
+        ec = EvalCase(input="q", output="a", messages=MESSAGES)
+        score = await metric.a_measure(ec)
+
+        assert score.passed
+        assert score.value == 0.9
+        assert score.metadata["n_assistant_turns"] == 2
+        assert len(score.metadata["turn_scores"]) == 2
+
+    async def test_per_turn_breakdown(self):
+        llm = MockLLM(
+            responses=[
+                {"reasoning": "First turn good", "score": 0.8},
+                {"reasoning": "Second turn excellent", "score": 1.0},
+            ]
+        )
+        metric = ConversationalGEvalMetric(
+            llm=llm,
+            criteria="Accuracy",
+        )
+        ec = EvalCase(input="q", output="a", messages=MESSAGES)
+        score = await metric.a_measure(ec)
+
+        assert score.value == 0.9  # mean of 0.8 and 1.0
+        assert score.metadata["turn_scores"][0]["score"] == 0.8
+        assert score.metadata["turn_scores"][1]["score"] == 1.0
+        assert score.metadata["turn_scores"][0]["reasoning"] == "First turn good"
+
+    async def test_missing_messages(self):
+        llm = MockLLM()
+        metric = ConversationalGEvalMetric(llm=llm, criteria="test")
+        ec = EvalCase(input="q", output="a")
+        score = await metric.a_measure(ec)
+        assert score.value == 0.0
+        assert "missing" in score.reason
+
+    async def test_single_turn(self):
+        llm = MockLLM()
+        metric = ConversationalGEvalMetric(llm=llm, criteria="test")
+        ec = EvalCase(
+            input="q",
+            output="a",
+            messages=[Message(role="user", content="hi")],
+        )
+        score = await metric.a_measure(ec)
+        assert score.value == 0.0
+
+    async def test_no_assistant_turns(self):
+        llm = MockLLM()
+        metric = ConversationalGEvalMetric(llm=llm, criteria="test")
+        ec = EvalCase(
+            input="q",
+            output="a",
+            messages=[
+                Message(role="user", content="hi"),
+                Message(role="user", content="hello?"),
+            ],
+        )
+        score = await metric.a_measure(ec)
+        assert score.value == 0.0
+        assert "no assistant turns" in score.reason
+
+    async def test_sliding_window_view(self):
+        long_messages = []
+        for i in range(10):
+            long_messages.append(Message(role="user", content=f"Question {i}"))
+            long_messages.append(Message(role="assistant", content=f"Answer {i}"))
+
+        llm = MockLLM(default={"reasoning": "ok", "score": 0.85})
+        metric = ConversationalGEvalMetric(
+            llm=llm,
+            criteria="Relevancy",
+            view=MultiTurnView.SLIDING_WINDOW,
+            window_size=3,
+        )
+        ec = EvalCase(input="q", output="a", messages=long_messages)
+        score = await metric.a_measure(ec)
+
+        assert score.passed
+        assert score.metadata["n_assistant_turns"] == 10
+
+    async def test_evaluation_steps(self):
+        llm = MockLLM(default={"reasoning": "followed steps", "score": 0.75})
+        metric = ConversationalGEvalMetric(
+            llm=llm,
+            criteria="Helpfulness",
+            evaluation_steps=["Check accuracy", "Check completeness"],
+        )
+        ec = EvalCase(input="q", output="a", messages=MESSAGES)
+        score = await metric.a_measure(ec)
+        assert score.value == 0.75
+
+    async def test_score_clamping(self):
+        llm = MockLLM(default={"reasoning": "test", "score": 1.5})
+        metric = ConversationalGEvalMetric(llm=llm, criteria="test")
+        ec = EvalCase(input="q", output="a", messages=MESSAGES)
+        score = await metric.a_measure(ec)
+        assert score.value == 1.0
+
+    async def test_negative_score_clamping(self):
+        llm = MockLLM(default={"reasoning": "test", "score": -0.5})
+        metric = ConversationalGEvalMetric(llm=llm, criteria="test")
+        ec = EvalCase(input="q", output="a", messages=MESSAGES)
+        score = await metric.a_measure(ec)
+        assert score.value == 0.0
+
+    def test_sync_measure(self):
+        llm = MockLLM(default={"reasoning": "sync works", "score": 0.8})
+        metric = ConversationalGEvalMetric(llm=llm, criteria="test")
+        ec = EvalCase(input="q", output="a", messages=MESSAGES)
+        score = metric.measure(ec)
+        assert score.passed
+        assert score.value == 0.8
+
+    async def test_threshold_customization(self):
+        llm = MockLLM(default={"reasoning": "ok", "score": 0.6})
+        metric = ConversationalGEvalMetric(llm=llm, criteria="test", threshold=0.5)
+        ec = EvalCase(input="q", output="a", messages=MESSAGES)
+        score = await metric.a_measure(ec)
+        assert score.passed  # 0.6 > 0.5

--- a/tests/metrics/test_turn_operational.py
+++ b/tests/metrics/test_turn_operational.py
@@ -1,0 +1,99 @@
+"""Tests for per-turn operational metrics."""
+
+import pytest
+
+from harness_evals.core.eval_case import EvalCase
+from harness_evals.core.types import Message
+from harness_evals.metrics.operational.turn_latency import TurnLatencyMetric
+from harness_evals.metrics.operational.turn_token_cost import TurnTokenCostMetric
+
+
+MESSAGES_WITH_LATENCY = [
+    Message(role="user", content="q1"),
+    Message(role="assistant", content="a1", latency_ms=200.0),
+    Message(role="user", content="q2"),
+    Message(role="assistant", content="a2", latency_ms=400.0),
+]
+
+MESSAGES_WITH_TOKENS = [
+    Message(role="user", content="q1"),
+    Message(role="assistant", content="a1", token_count=50),
+    Message(role="user", content="q2"),
+    Message(role="assistant", content="a2", token_count=150),
+]
+
+
+@pytest.mark.unit
+class TestTurnLatencyMetric:
+    def test_within_budget(self):
+        ec = EvalCase(input="q", output="a", messages=MESSAGES_WITH_LATENCY)
+        score = TurnLatencyMetric(max_ms_per_turn=500, threshold=0.3).measure(ec)
+        assert score.passed
+        assert score.value == pytest.approx(0.4)  # mean of (1-200/500, 1-400/500) = mean(0.6, 0.2) = 0.4
+        assert score.metadata["turn_latencies"] == [200.0, 400.0]
+        assert score.metadata["mean_latency_ms"] == 300.0
+
+    def test_over_budget(self):
+        ec = EvalCase(input="q", output="a", messages=MESSAGES_WITH_LATENCY)
+        score = TurnLatencyMetric(max_ms_per_turn=300, threshold=0.8).measure(ec)
+        assert not score.passed  # mean = (1-200/300 + 0.0) / 2 = 0.333
+        assert score.value < 0.5
+
+    def test_no_messages(self):
+        ec = EvalCase(input="q", output="a")
+        score = TurnLatencyMetric().measure(ec)
+        assert score.value == 0.0
+        assert "no messages" in score.reason
+
+    def test_no_assistant_latency_data(self):
+        ec = EvalCase(input="q", output="a", messages=[
+            Message(role="user", content="q"),
+            Message(role="assistant", content="a"),  # no latency_ms
+        ])
+        score = TurnLatencyMetric().measure(ec)
+        assert score.value == 0.0
+        assert "no latency" in score.reason
+
+    def test_partial_latency_data_skips_missing(self):
+        messages = [
+            Message(role="user", content="q1"),
+            Message(role="assistant", content="a1", latency_ms=200.0),
+            Message(role="user", content="q2"),
+            Message(role="assistant", content="a2"),  # missing latency
+        ]
+        ec = EvalCase(input="q", output="a", messages=messages)
+        score = TurnLatencyMetric(max_ms_per_turn=500).measure(ec)
+        # Only turn 1 scored: (1 - 200/500) = 0.6
+        assert score.value == pytest.approx(0.6)
+        assert score.metadata["turn_latencies"] == [200.0]
+
+
+@pytest.mark.unit
+class TestTurnTokenCostMetric:
+    def test_within_budget(self):
+        ec = EvalCase(input="q", output="a", messages=MESSAGES_WITH_TOKENS)
+        score = TurnTokenCostMetric(max_tokens_per_turn=200, threshold=0.4).measure(ec)
+        assert score.passed
+        assert score.value == pytest.approx(0.5)  # mean of (1-50/200, 1-150/200) = mean(0.75, 0.25) = 0.5
+        assert score.metadata["turn_token_counts"] == [50, 150]
+        assert score.metadata["total_tokens"] == 200
+
+    def test_over_budget(self):
+        ec = EvalCase(input="q", output="a", messages=MESSAGES_WITH_TOKENS)
+        score = TurnTokenCostMetric(max_tokens_per_turn=100, threshold=0.8).measure(ec)
+        assert not score.passed
+
+    def test_no_messages(self):
+        ec = EvalCase(input="q", output="a")
+        score = TurnTokenCostMetric().measure(ec)
+        assert score.value == 0.0
+        assert "no messages" in score.reason
+
+    def test_no_token_data(self):
+        ec = EvalCase(input="q", output="a", messages=[
+            Message(role="user", content="q"),
+            Message(role="assistant", content="a"),  # no token_count
+        ])
+        score = TurnTokenCostMetric().measure(ec)
+        assert score.value == 0.0
+        assert "no token" in score.reason

--- a/tests/metrics/test_turn_operational.py
+++ b/tests/metrics/test_turn_operational.py
@@ -7,7 +7,6 @@ from harness_evals.core.types import Message
 from harness_evals.metrics.operational.turn_latency import TurnLatencyMetric
 from harness_evals.metrics.operational.turn_token_cost import TurnTokenCostMetric
 
-
 MESSAGES_WITH_LATENCY = [
     Message(role="user", content="q1"),
     Message(role="assistant", content="a1", latency_ms=200.0),
@@ -67,6 +66,16 @@ class TestTurnLatencyMetric:
         assert score.value == pytest.approx(0.6)
         assert score.metadata["turn_latencies"] == [200.0]
 
+    def test_negative_latency_skipped(self):
+        messages = [
+            Message(role="user", content="q"),
+            Message(role="assistant", content="a", latency_ms=-100.0),
+        ]
+        ec = EvalCase(input="q", output="a", messages=messages)
+        score = TurnLatencyMetric(max_ms_per_turn=500).measure(ec)
+        assert score.value == 0.0
+        assert score.metadata is None or score.metadata.get("n_turns_scored", 0) == 0
+
 
 @pytest.mark.unit
 class TestTurnTokenCostMetric:
@@ -76,12 +85,14 @@ class TestTurnTokenCostMetric:
         assert score.passed
         assert score.value == pytest.approx(0.5)  # mean of (1-50/200, 1-150/200) = mean(0.75, 0.25) = 0.5
         assert score.metadata["turn_token_counts"] == [50, 150]
-        assert score.metadata["total_tokens"] == 200
+        assert score.metadata["mean_token_count"] == pytest.approx(100.0)
 
     def test_over_budget(self):
         ec = EvalCase(input="q", output="a", messages=MESSAGES_WITH_TOKENS)
         score = TurnTokenCostMetric(max_tokens_per_turn=100, threshold=0.8).measure(ec)
         assert not score.passed
+        # scores = [1-50/100, 0.0] = [0.5, 0.0], mean = 0.25
+        assert score.value == pytest.approx(0.25)
 
     def test_no_messages(self):
         ec = EvalCase(input="q", output="a")
@@ -97,3 +108,26 @@ class TestTurnTokenCostMetric:
         score = TurnTokenCostMetric().measure(ec)
         assert score.value == 0.0
         assert "no token" in score.reason
+
+    def test_partial_token_data_skips_missing(self):
+        messages = [
+            Message(role="user", content="q1"),
+            Message(role="assistant", content="a1", token_count=500),
+            Message(role="user", content="q2"),
+            Message(role="assistant", content="a2"),  # missing token_count
+        ]
+        ec = EvalCase(input="q", output="a", messages=messages)
+        score = TurnTokenCostMetric(max_tokens_per_turn=1000).measure(ec)
+        # Only turn 1 scored: (1 - 500/1000) = 0.5
+        assert score.value == pytest.approx(0.5)
+        assert score.metadata["n_turns_scored"] == 1
+
+    def test_negative_token_count_skipped(self):
+        messages = [
+            Message(role="user", content="q"),
+            Message(role="assistant", content="a", token_count=-100),
+        ]
+        ec = EvalCase(input="q", output="a", messages=messages)
+        score = TurnTokenCostMetric(max_tokens_per_turn=1000).measure(ec)
+        assert score.value == 0.0
+        assert score.metadata is None or score.metadata.get("n_turns_scored", 0) == 0

--- a/tests/metrics/test_turn_operational.py
+++ b/tests/metrics/test_turn_operational.py
@@ -45,10 +45,14 @@ class TestTurnLatencyMetric:
         assert "no messages" in score.reason
 
     def test_no_assistant_latency_data(self):
-        ec = EvalCase(input="q", output="a", messages=[
-            Message(role="user", content="q"),
-            Message(role="assistant", content="a"),  # no latency_ms
-        ])
+        ec = EvalCase(
+            input="q",
+            output="a",
+            messages=[
+                Message(role="user", content="q"),
+                Message(role="assistant", content="a"),  # no latency_ms
+            ],
+        )
         score = TurnLatencyMetric().measure(ec)
         assert score.value == 0.0
         assert "no latency" in score.reason
@@ -101,10 +105,14 @@ class TestTurnTokenCostMetric:
         assert "no messages" in score.reason
 
     def test_no_token_data(self):
-        ec = EvalCase(input="q", output="a", messages=[
-            Message(role="user", content="q"),
-            Message(role="assistant", content="a"),  # no token_count
-        ])
+        ec = EvalCase(
+            input="q",
+            output="a",
+            messages=[
+                Message(role="user", content="q"),
+                Message(role="assistant", content="a"),  # no token_count
+            ],
+        )
         score = TurnTokenCostMetric().measure(ec)
         assert score.value == 0.0
         assert "no token" in score.reason

--- a/tests/synthesizer/test_conversation_synthesizer.py
+++ b/tests/synthesizer/test_conversation_synthesizer.py
@@ -1,0 +1,119 @@
+"""Tests for ConversationSynthesizer."""
+
+import pytest
+
+from harness_evals.conversation.golden import ConversationGolden
+from harness_evals.core.types import Message
+from harness_evals.synthesizer.conversation import (
+    ConversationSynthesizer,
+    ScriptedConversationSynthesizer,
+)
+from tests.conftest import MockLLM
+
+
+SCENARIO_RESPONSE = {
+    "scenarios": [
+        {
+            "scenario": "User wants to know refund policy",
+            "expected_outcome": "Agent explains 30-day refund window and process",
+            "user_persona": "Frustrated customer who bought last week",
+        },
+        {
+            "scenario": "User needs help with password reset",
+            "expected_outcome": "Agent guides user through reset steps successfully",
+            "user_persona": "Non-technical user",
+        },
+    ]
+}
+
+SCRIPTED_RESPONSE = {
+    "conversations": [
+        {
+            "scenario": "User asks about shipping time",
+            "expected_outcome": "User gets a clear shipping ETA",
+            "turns": [
+                {"role": "user", "content": "How long does shipping take?"},
+                {"role": "assistant", "content": "Standard shipping takes 3-5 business days."},
+                {"role": "user", "content": "What about express?"},
+                {"role": "assistant", "content": "Express shipping takes 1-2 business days."},
+            ],
+        }
+    ]
+}
+
+
+@pytest.mark.unit
+class TestConversationSynthesizer:
+    async def test_generates_scenario_goldens(self):
+        llm = MockLLM(default=SCENARIO_RESPONSE)
+        synth = ConversationSynthesizer(llm=llm)
+        goldens = await synth.generate(["Customer support documentation."], n=2)
+        assert len(goldens) == 2
+        assert all(isinstance(g, ConversationGolden) for g in goldens)
+        assert goldens[0].scenario == "User wants to know refund policy"
+        assert goldens[0].expected_outcome == "Agent explains 30-day refund window and process"
+        assert goldens[0].user_persona == "Frustrated customer who bought last week"
+        assert goldens[0].turns is None  # scenario mode has no turns
+
+    async def test_respects_n(self):
+        llm = MockLLM(default=SCENARIO_RESPONSE)
+        synth = ConversationSynthesizer(llm=llm)
+        goldens = await synth.generate(["doc"], n=1)
+        assert len(goldens) <= 1
+
+    async def test_empty_document_returns_empty(self):
+        llm = MockLLM(default={"scenarios": []})
+        synth = ConversationSynthesizer(llm=llm)
+        goldens = await synth.generate(["   "], n=5)
+        assert goldens == []
+
+    async def test_deduplicates_by_scenario(self):
+        duplicate_response = {
+            "scenarios": [
+                {"scenario": "same", "expected_outcome": "o1", "user_persona": None},
+                {"scenario": "same", "expected_outcome": "o2", "user_persona": None},
+            ]
+        }
+        llm = MockLLM(default=duplicate_response)
+        synth = ConversationSynthesizer(llm=llm)
+        goldens = await synth.generate(["doc"], n=5)
+        assert len(goldens) == 1
+
+
+@pytest.mark.unit
+class TestScriptedConversationSynthesizer:
+    async def test_generates_scripted_goldens(self):
+        llm = MockLLM(default=SCRIPTED_RESPONSE)
+        synth = ScriptedConversationSynthesizer(llm=llm)
+        goldens = await synth.generate(["E-commerce help docs."], n=1)
+        assert len(goldens) == 1
+        g = goldens[0]
+        assert isinstance(g, ConversationGolden)
+        assert g.scenario == "User asks about shipping time"
+        assert g.turns is not None
+        assert len(g.turns) == 4
+        assert all(isinstance(t, Message) for t in g.turns)
+        assert g.turns[0].role == "user"
+        assert g.turns[1].role == "assistant"
+
+    async def test_skips_invalid_turns(self):
+        response = {
+            "conversations": [
+                {
+                    "scenario": "test",
+                    "expected_outcome": "done",
+                    "turns": [
+                        {"role": "user", "content": "hi"},
+                        # missing role — should be skipped gracefully
+                        {"content": "oops"},
+                        {"role": "assistant", "content": "hello"},
+                    ],
+                }
+            ]
+        }
+        llm = MockLLM(default=response)
+        synth = ScriptedConversationSynthesizer(llm=llm)
+        goldens = await synth.generate(["doc"], n=1)
+        assert len(goldens) == 1
+        # Invalid turn skipped, 2 valid turns remain
+        assert len(goldens[0].turns) == 2

--- a/tests/synthesizer/test_conversation_synthesizer.py
+++ b/tests/synthesizer/test_conversation_synthesizer.py
@@ -53,12 +53,14 @@ class TestConversationSynthesizer:
         assert goldens[0].expected_outcome == "Agent explains 30-day refund window and process"
         assert goldens[0].user_persona == "Frustrated customer who bought last week"
         assert goldens[0].turns is None  # scenario mode has no turns
+        assert goldens[0].metadata["task_type"] == "conversation"
+        assert goldens[0].metadata["difficulty"] == "mixed"
 
     async def test_respects_n(self):
         llm = MockLLM(default=SCENARIO_RESPONSE)
         synth = ConversationSynthesizer(llm=llm)
         goldens = await synth.generate(["doc"], n=1)
-        assert len(goldens) <= 1
+        assert len(goldens) == 1
 
     async def test_empty_document_returns_empty(self):
         llm = MockLLM(default={"scenarios": []})
@@ -94,6 +96,28 @@ class TestScriptedConversationSynthesizer:
         assert all(isinstance(t, Message) for t in g.turns)
         assert g.turns[0].role == "user"
         assert g.turns[1].role == "assistant"
+        assert g.metadata["task_type"] == "conversation_scripted"
+        assert g.metadata["difficulty"] == "mixed"
+
+    async def test_deduplicates_by_scenario(self):
+        duplicate_response = {
+            "conversations": [
+                {
+                    "scenario": "same",
+                    "expected_outcome": "o1",
+                    "turns": [{"role": "user", "content": "hi"}],
+                },
+                {
+                    "scenario": "same",
+                    "expected_outcome": "o2",
+                    "turns": [{"role": "assistant", "content": "hello"}],
+                },
+            ]
+        }
+        llm = MockLLM(default=duplicate_response)
+        synth = ScriptedConversationSynthesizer(llm=llm)
+        goldens = await synth.generate(["doc"], n=5)
+        assert len(goldens) == 1
 
     async def test_skips_invalid_turns(self):
         response = {

--- a/tests/synthesizer/test_conversation_synthesizer.py
+++ b/tests/synthesizer/test_conversation_synthesizer.py
@@ -10,7 +10,6 @@ from harness_evals.synthesizer.conversation import (
 )
 from tests.conftest import MockLLM
 
-
 SCENARIO_RESPONSE = {
     "scenarios": [
         {

--- a/tests/test_runner_conversation.py
+++ b/tests/test_runner_conversation.py
@@ -1,0 +1,87 @@
+"""Tests for evaluate_dataset() with ConversationGolden inputs."""
+
+import pytest
+
+from harness_evals.conversation.golden import ConversationGolden
+from harness_evals.core.eval_case import EvalCase
+from harness_evals.core.golden import Golden
+from harness_evals.core.runner import evaluate_dataset
+from harness_evals.core.score import Score
+from harness_evals.core.types import Message
+from harness_evals.metrics.deterministic.exact_match import ExactMatchMetric
+from tests.conftest import MockLLM
+
+
+class SimulatorMockLLM(MockLLM):
+    async def generate(self, prompt: str, **kwargs) -> str:
+        return "What is the refund policy?"
+
+    async def generate_json(self, prompt: str, schema: dict, **kwargs) -> dict:
+        return {"achieved": True, "reasoning": "done"}
+
+
+async def mock_agent_fn_single(golden: Golden) -> EvalCase:
+    return EvalCase(input=str(golden.input), output="answer")
+
+
+async def mock_agent_fn_conv(messages: list[Message]) -> Message:
+    return Message(role="assistant", content="Here is your answer.")
+
+
+@pytest.mark.unit
+class TestEvaluateDatasetWithConversationGolden:
+    async def test_single_turn_goldens_unchanged(self):
+        goldens = [Golden(input="q1", expected="a1"), Golden(input="q2", expected="a2")]
+        metrics = [ExactMatchMetric()]
+        results = await evaluate_dataset(goldens, mock_agent_fn_single, metrics)
+        assert len(results) == 2
+        assert all(isinstance(scores, list) for scores in results)
+
+    async def test_conversation_goldens_require_simulator_llm(self):
+        goldens = [ConversationGolden(scenario="test", expected_outcome="done")]
+        with pytest.raises(ValueError, match="simulator_llm"):
+            await evaluate_dataset(goldens, mock_agent_fn_conv, [])
+
+    async def test_conversation_goldens_with_simulator_llm(self):
+        llm = SimulatorMockLLM()
+        goldens = [
+            ConversationGolden(scenario="Ask about refund", expected_outcome="Explained"),
+        ]
+        metrics = [ExactMatchMetric()]
+        results = await evaluate_dataset(
+            goldens,
+            mock_agent_fn_conv,
+            metrics,
+            simulator_llm=llm,
+        )
+        assert len(results) == 1
+        assert isinstance(results[0], list)
+
+    async def test_mixed_goldens_raises(self):
+        """Mixed lists (Golden + ConversationGolden) should raise TypeError."""
+        mixed = [Golden(input="q", expected="a"), ConversationGolden(scenario="s", expected_outcome="o")]
+        with pytest.raises(TypeError, match="mixed"):
+            await evaluate_dataset(mixed, mock_agent_fn_conv, [], simulator_llm=MockLLM())
+
+    async def test_conversation_golden_replay_mode(self):
+        """Pre-scripted turns skip simulation and use replay mode."""
+        llm = MockLLM()  # Should not be called for simulation
+        turns = [
+            Message(role="user", content="Hi"),
+            Message(role="assistant", content="Hello!"),
+        ]
+        goldens = [
+            ConversationGolden(
+                scenario="Greeting",
+                expected_outcome="Polite exchange",
+                turns=turns,
+            )
+        ]
+        metrics = [ExactMatchMetric()]
+        results = await evaluate_dataset(
+            goldens,
+            mock_agent_fn_conv,
+            metrics,
+            simulator_llm=llm,
+        )
+        assert len(results) == 1

--- a/tests/test_runner_conversation.py
+++ b/tests/test_runner_conversation.py
@@ -6,7 +6,6 @@ from harness_evals.conversation.golden import ConversationGolden
 from harness_evals.core.eval_case import EvalCase
 from harness_evals.core.golden import Golden
 from harness_evals.core.runner import evaluate_dataset
-from harness_evals.core.score import Score
 from harness_evals.core.types import Message
 from harness_evals.metrics.deterministic.exact_match import ExactMatchMetric
 from tests.conftest import MockLLM

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -129,7 +129,7 @@ class TestMessage:
         msg = Message(role="assistant", content="hi", latency_ms=100.0)
         d = msg.to_dict()
         assert d["latency_ms"] == 100.0
-        assert "token_count" not in d   # None omitted
+        assert "token_count" not in d  # None omitted
 
     def test_message_from_dict_roundtrip_with_operational(self):
         msg = Message(role="assistant", content="resp", latency_ms=55.0, token_count=10, cost_usd=0.001)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -112,3 +112,30 @@ class TestMessage:
             tool_calls=[ToolCall(name="search", input={"q": "foo"}, output="bar")],
         )
         assert Message.from_dict(msg.to_dict()) == msg
+
+    def test_message_operational_fields_default_none(self):
+        msg = Message(role="user", content="hi")
+        assert msg.latency_ms is None
+        assert msg.token_count is None
+        assert msg.cost_usd is None
+
+    def test_message_operational_fields_set(self):
+        msg = Message(role="assistant", content="done", latency_ms=120.5, token_count=42, cost_usd=0.0003)
+        assert msg.latency_ms == 120.5
+        assert msg.token_count == 42
+        assert msg.cost_usd == 0.0003
+
+    def test_message_to_dict_includes_operational_when_set(self):
+        msg = Message(role="assistant", content="hi", latency_ms=100.0)
+        d = msg.to_dict()
+        assert d["latency_ms"] == 100.0
+        assert "token_count" not in d   # None omitted
+
+    def test_message_from_dict_roundtrip_with_operational(self):
+        msg = Message(role="assistant", content="resp", latency_ms=55.0, token_count=10, cost_usd=0.001)
+        assert Message.from_dict(msg.to_dict()) == msg
+
+    def test_message_from_dict_backward_compat_no_operational(self):
+        msg = Message.from_dict({"role": "user", "content": "hello"})
+        assert msg.latency_ms is None
+        assert msg.token_count is None


### PR DESCRIPTION
## Summary

Closes the remaining multi-turn evaluation gaps identified against DeepEval's feature set.

### Changes

**`Message` operational fields** (`src/harness_evals/core/types.py`)
- Added optional `latency_ms: float`, `token_count: int`, `cost_usd: float` fields to carry per-turn observability data through the message history
- Fully backward-compatible — all fields default to `None`, `to_dict()`/`from_dict()` handle missing keys

**`TurnLatencyMetric` / `TurnTokenCostMetric`** (`src/harness_evals/metrics/operational/`)
- Score per-turn latency and token usage from `Message.latency_ms` / `Message.token_count` on assistant turns
- Scoring: `max(0, 1 - value / budget)` per turn, mean-aggregated; negative values skipped
- Metadata includes `turn_latencies`/`turn_token_counts`, `mean_latency_ms`/`mean_token_count`, `n_turns_scored`

**`ConversationSynthesizer` / `ScriptedConversationSynthesizer`** (`src/harness_evals/synthesizer/conversation.py`)
- Two new synthesizers generating `ConversationGolden` datasets from source documents
- `ConversationSynthesizer` (`task_type="conversation"`) — produces scenario + expected_outcome + user_persona (no turns), intended for use with `ConversationSimulator`
- `ScriptedConversationSynthesizer` (`task_type="conversation_scripted"`) — produces fully scripted `turns: list[Message]` for direct replay
- Both registered in the `Synthesizer` facade; deduplication by scenario name

**Unified `evaluate_dataset()`** (`src/harness_evals/core/runner.py`)
- Extended to accept `list[Golden] | list[ConversationGolden]` with a new `simulator_llm` kwarg
- `ConversationGolden` inputs route through `ConversationSimulator.simulate_batch()`; pre-scripted turns bypass simulation (replay mode)
- Mixed lists raise `TypeError`; missing `simulator_llm` for conversation inputs raises `ValueError`
- Existing single-turn callers are unaffected

**`ConversationalGEvalMetric`** (`src/harness_evals/metrics/conversation/conversational_geval.py`)
- LLM judge that scores each assistant turn individually against a user-defined criterion
- Supports `MultiTurnView.FULL_CONVERSATION` (all messages) and `MultiTurnView.SLIDING_WINDOW` (last N turns)
- Returns mean score with per-turn breakdown in `metadata["turn_scores"]`

**Per-turn scoring backfill** (`coherence.py`, `turn_relevancy.py`, `knowledge_retention.py`)
- Opted into `_per_turn=True` on `LLMConversationMetric` — these metrics now also store `metadata["turn_scores"]` alongside the aggregate score

## Test plan

- [ ] 907 tests pass locally (Python 3.11), 4 skipped
- [ ] `ruff check` + `ruff format --check` clean across all 220 files
- [ ] Public API verified: `ConversationSynthesizer`, `ScriptedConversationSynthesizer`, `TurnLatencyMetric`, `TurnTokenCostMetric`, `ConversationalGEvalMetric`, `evaluate_dataset(simulator_llm=...)`
- [ ] CI matrix: Python 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)