### PR TITLE
feat(metrics): add WebhookMetric for external HTTP endpoint validation

### DIFF
--- a/src/harness_evals/metrics/__init__.py
+++ b/src/harness_evals/metrics/__init__.py
@@ -34,6 +34,7 @@ from harness_evals.metrics.deterministic.exact_match import ExactMatchMetric
 from harness_evals.metrics.deterministic.list_contains import ListContainsMetric
 from harness_evals.metrics.deterministic.numeric_diff import NumericDiffMetric
 from harness_evals.metrics.deterministic.regex_match import RegexMetric
+from harness_evals.metrics.deterministic.webhook import WebhookMetric
 from harness_evals.metrics.llm_judge.dag import (
     BinaryJudgementNode,
     DAGMetric,
@@ -104,6 +105,7 @@ __all__ = [
     "ContainsMetric",
     "RegexMetric",
     "NumericDiffMetric",
+    "WebhookMetric",
     "JsonDiffMetric",
     "SchemaValidationMetric",
     "StructuralSimilarityMetric",

--- a/src/harness_evals/metrics/deterministic/__init__.py
+++ b/src/harness_evals/metrics/deterministic/__init__.py
@@ -3,5 +3,6 @@ from harness_evals.metrics.deterministic.exact_match import ExactMatchMetric
 from harness_evals.metrics.deterministic.list_contains import ListContainsMetric
 from harness_evals.metrics.deterministic.numeric_diff import NumericDiffMetric
 from harness_evals.metrics.deterministic.regex_match import RegexMetric
+from harness_evals.metrics.deterministic.webhook import WebhookMetric
 
-__all__ = ["ExactMatchMetric", "ContainsMetric", "RegexMetric", "NumericDiffMetric", "ListContainsMetric"]
+__all__ = ["ExactMatchMetric", "ContainsMetric", "RegexMetric", "NumericDiffMetric", "ListContainsMetric", "WebhookMetric"]

--- a/src/harness_evals/metrics/deterministic/webhook.py
+++ b/src/harness_evals/metrics/deterministic/webhook.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from harness_evals._async_compat import _run_async
+from harness_evals.core.eval_case import EvalCase
+from harness_evals.core.metric import BaseMetric, Dimension
+from harness_evals.core.score import Score
+
+if TYPE_CHECKING:
+    import httpx
+
+
+class WebhookMetric(BaseMetric):
+    """Score LLM outputs by calling an external HTTP endpoint.
+
+    User must explicitly configure how to interpret the response via one of:
+    - response_fn: full control, takes httpx.Response, returns Score
+    - response_key: name the boolean field in JSON response (optionally pair with score_key)
+    - use_status_code: 2xx = pass (1.0), anything else = fail (0.0)
+
+    Default payload (when no payload_fn): {"input": ..., "output": ..., "expected": ..., "context": ...}
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        payload_fn: Callable[[EvalCase], dict] | None = None,
+        response_fn: Callable[[httpx.Response], Score] | None = None,
+        response_key: str | None = None,
+        score_key: str | None = None,
+        use_status_code: bool = False,
+        method: str = "POST",
+        timeout: float = 30.0,
+        threshold: float = 1.0,
+        name: str = "webhook",
+        dimension: Dimension = Dimension.CORRECTNESS,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(name=name, dimension=dimension, threshold=threshold, **kwargs)
+
+        modes_set = sum([response_fn is not None, response_key is not None, use_status_code])
+        if modes_set == 0:
+            raise ValueError(
+                "Must specify exactly one response handling mode: response_fn, response_key, or use_status_code=True"
+            )
+        if modes_set > 1:
+            raise ValueError("Cannot specify multiple response handling modes simultaneously")
+
+        if score_key is not None and response_key is None:
+            raise ValueError("score_key requires response_key to be set")
+
+        self.url = url
+        self.headers = headers
+        self.payload_fn = payload_fn
+        self.response_fn = response_fn
+        self.response_key = response_key
+        self.score_key = score_key
+        self.use_status_code = use_status_code
+        self.method = method.upper()
+        self.timeout = timeout
+
+    def _build_default_payload(self, eval_case: EvalCase) -> dict:
+        payload = {"input": eval_case.input, "output": eval_case.output}
+        if eval_case.expected is not None:
+            payload["expected"] = eval_case.expected
+        if eval_case.context is not None:
+            payload["context"] = eval_case.context
+        return payload
+
+    def _parse_response(self, response: httpx.Response) -> Score:
+        if self.response_fn is not None:
+            return self.response_fn(response)
+
+        if self.use_status_code:
+            value = 1.0 if 200 <= response.status_code < 300 else 0.0
+            reason = None if value == 1.0 else f"HTTP {response.status_code}"
+            return Score(name=self.name, value=value, threshold=self.threshold, reason=reason)
+
+        try:
+            json_data = response.json()
+        except Exception as e:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason=f"Invalid response format: {e}",
+            )
+
+        if self.response_key is None:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason="No response_key configured",
+            )
+
+        if self.response_key not in json_data:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason=f"Response missing key: {self.response_key}",
+            )
+
+        passed = json_data[self.response_key]
+        if not isinstance(passed, bool):
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason=f"Response key {self.response_key} is not boolean",
+            )
+
+        if self.score_key is not None and self.score_key in json_data:
+            try:
+                value = float(json_data[self.score_key])
+                value = max(0.0, min(1.0, value))
+            except (TypeError, ValueError):
+                return Score(
+                    name=self.name,
+                    value=0.0,
+                    threshold=self.threshold,
+                    reason=f"Invalid score value for {self.score_key}",
+                )
+        else:
+            value = 1.0 if passed else 0.0
+
+        return Score(name=self.name, value=value, threshold=self.threshold)
+
+    def measure(self, eval_case: EvalCase) -> Score:
+        return _run_async(self.a_measure(eval_case))
+
+    async def a_measure(self, eval_case: EvalCase) -> Score:
+        try:
+            import httpx
+        except ImportError as e:
+            raise ImportError("WebhookMetric requires httpx. Install with: pip install 'harness-evals[harness]'") from e
+
+        payload = self.payload_fn(eval_case) if self.payload_fn else self._build_default_payload(eval_case)
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.request(
+                    method=self.method,
+                    url=self.url,
+                    json=payload,
+                    headers=self.headers,
+                )
+
+                if not self.use_status_code and not (200 <= response.status_code < 300):
+                    return Score(
+                        name=self.name,
+                        value=0.0,
+                        threshold=self.threshold,
+                        reason=f"HTTP error {response.status_code}",
+                    )
+
+                return self._parse_response(response)
+
+        except httpx.TimeoutException:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason="Request timed out",
+            )
+        except Exception as e:
+            return Score(
+                name=self.name,
+                value=0.0,
+                threshold=self.threshold,
+                reason=f"Request failed: {type(e).__name__}: {e}",
+            )

--- a/tests/metrics/test_webhook.py
+++ b/tests/metrics/test_webhook.py
@@ -1,0 +1,492 @@
+"""Tests for WebhookMetric."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from harness_evals.core.eval_case import EvalCase
+from harness_evals.core.score import Score
+from harness_evals.metrics.deterministic.webhook import WebhookMetric
+
+
+def _mock_httpx_response(payload: dict, status_code: int = 200) -> httpx.Response:
+    """Build a mock httpx.Response with a canned JSON body."""
+    content = json.dumps(payload).encode()
+    return httpx.Response(status_code=status_code, content=content)
+
+
+@pytest.mark.unit
+class TestWebhookMetricInit:
+    def test_no_response_mode_raises(self):
+        with pytest.raises(ValueError, match="Must specify exactly one response handling mode"):
+            WebhookMetric(url="http://example.com/validate")
+
+    def test_multiple_response_modes_raises(self):
+        with pytest.raises(ValueError, match="Cannot specify multiple response handling modes"):
+            WebhookMetric(
+                url="http://example.com/validate",
+                response_key="valid",
+                use_status_code=True,
+            )
+
+        with pytest.raises(ValueError, match="Cannot specify multiple response handling modes"):
+            WebhookMetric(
+                url="http://example.com/validate",
+                response_fn=lambda r: Score(name="test", value=1.0, threshold=1.0),
+                use_status_code=True,
+            )
+
+    def test_score_key_without_response_key_raises(self):
+        with pytest.raises(ValueError, match="score_key requires response_key"):
+            WebhookMetric(
+                url="http://example.com/validate",
+                use_status_code=True,
+                score_key="confidence",
+            )
+
+    def test_valid_response_key_mode(self):
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid")
+        assert metric.response_key == "is_valid"
+
+    def test_valid_status_code_mode(self):
+        metric = WebhookMetric(url="http://example.com/validate", use_status_code=True)
+        assert metric.use_status_code is True
+
+    def test_valid_response_fn_mode(self):
+        def fn(r: httpx.Response) -> Score:
+            return Score(name="test", value=1.0, threshold=1.0)
+
+        metric = WebhookMetric(url="http://example.com/validate", response_fn=fn)
+        assert metric.response_fn is fn
+
+
+@pytest.mark.unit
+class TestWebhookMetricResponseKey:
+    @pytest.mark.asyncio
+    async def test_response_key_pass(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid")
+
+        resp = _mock_httpx_response({"is_valid": True})
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert score.passed
+            assert score.value == 1.0
+
+    @pytest.mark.asyncio
+    async def test_response_key_fail(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid")
+
+        resp = _mock_httpx_response({"is_valid": False})
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert not score.passed
+            assert score.value == 0.0
+
+    @pytest.mark.asyncio
+    async def test_response_key_missing(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid")
+
+        resp = _mock_httpx_response({"other_key": True})
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert not score.passed
+            assert "missing key" in score.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_response_key_not_boolean(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid")
+
+        resp = _mock_httpx_response({"is_valid": "yes"})
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert not score.passed
+            assert "not boolean" in score.reason.lower()
+
+
+@pytest.mark.unit
+class TestWebhookMetricScoreKey:
+    @pytest.mark.asyncio
+    async def test_score_key_with_response_key(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(
+            url="http://example.com/validate",
+            response_key="is_valid",
+            score_key="confidence",
+            threshold=0.7,
+        )
+
+        resp = _mock_httpx_response({"is_valid": True, "confidence": 0.85})
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert score.value == 0.85
+            assert score.passed
+
+    @pytest.mark.asyncio
+    async def test_score_key_clamped(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(
+            url="http://example.com/validate",
+            response_key="is_valid",
+            score_key="confidence",
+        )
+
+        resp = _mock_httpx_response({"is_valid": True, "confidence": 1.5})
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert score.value == 1.0
+
+    @pytest.mark.asyncio
+    async def test_score_key_invalid_type(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(
+            url="http://example.com/validate",
+            response_key="is_valid",
+            score_key="confidence",
+        )
+
+        resp = _mock_httpx_response({"is_valid": True, "confidence": "high"})
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert score.value == 0.0
+            assert "Invalid score value" in score.reason
+
+
+@pytest.mark.unit
+class TestWebhookMetricStatusCode:
+    @pytest.mark.asyncio
+    async def test_status_code_success(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", use_status_code=True)
+
+        resp = _mock_httpx_response({}, status_code=200)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert score.passed
+            assert score.value == 1.0
+            assert score.reason is None
+
+    @pytest.mark.asyncio
+    async def test_status_code_failure(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", use_status_code=True)
+
+        resp = _mock_httpx_response({}, status_code=400)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert not score.passed
+            assert score.value == 0.0
+            assert "400" in score.reason
+
+
+@pytest.mark.unit
+class TestWebhookMetricResponseFn:
+    @pytest.mark.asyncio
+    async def test_response_fn_custom_logic(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+
+        def custom_parser(response: httpx.Response) -> Score:
+            data = response.json()
+            value = float(data.get("custom_score", 0))
+            return Score(
+                name="webhook",
+                value=value,
+                threshold=1.0,
+                reason=data.get("message"),
+            )
+
+        metric = WebhookMetric(url="http://example.com/validate", response_fn=custom_parser)
+
+        resp = _mock_httpx_response({"custom_score": 0.75, "message": "Good job"})
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert score.value == 0.75
+            assert score.reason == "Good job"
+
+
+@pytest.mark.unit
+class TestWebhookMetricPayload:
+    @pytest.mark.asyncio
+    async def test_default_payload(self):
+        ec = EvalCase(
+            input="test input",
+            output="test output",
+            expected="test expected",
+            context=["ctx1", "ctx2"],
+        )
+        metric = WebhookMetric(url="http://example.com/validate", use_status_code=True)
+
+        resp = _mock_httpx_response({}, status_code=200)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            await metric.a_measure(ec)
+
+            call_kwargs = mock_client.request.call_args[1]
+            assert call_kwargs["json"]["input"] == "test input"
+            assert call_kwargs["json"]["output"] == "test output"
+            assert call_kwargs["json"]["expected"] == "test expected"
+            assert call_kwargs["json"]["context"] == ["ctx1", "ctx2"]
+
+    @pytest.mark.asyncio
+    async def test_default_payload_without_optional_fields(self):
+        ec = EvalCase(input="test input", output="test output")
+        metric = WebhookMetric(url="http://example.com/validate", use_status_code=True)
+
+        resp = _mock_httpx_response({}, status_code=200)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            await metric.a_measure(ec)
+
+            call_kwargs = mock_client.request.call_args[1]
+            assert call_kwargs["json"]["input"] == "test input"
+            assert call_kwargs["json"]["output"] == "test output"
+            assert "expected" not in call_kwargs["json"]
+            assert "context" not in call_kwargs["json"]
+
+    @pytest.mark.asyncio
+    async def test_custom_payload_fn(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+
+        def custom_payload(eval_case: EvalCase) -> dict:
+            return {
+                "query": eval_case.input,
+                "response": eval_case.output,
+                "metadata": {"custom": "data"},
+            }
+
+        metric = WebhookMetric(
+            url="http://example.com/validate",
+            payload_fn=custom_payload,
+            use_status_code=True,
+        )
+
+        resp = _mock_httpx_response({}, status_code=200)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            await metric.a_measure(ec)
+
+            call_kwargs = mock_client.request.call_args[1]
+            assert call_kwargs["json"]["query"] == "test input"
+            assert call_kwargs["json"]["response"] == "test output"
+            assert call_kwargs["json"]["metadata"]["custom"] == "data"
+
+
+@pytest.mark.unit
+class TestWebhookMetricErrorHandling:
+    @pytest.mark.asyncio
+    async def test_http_error_not_status_code_mode(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid")
+
+        resp = _mock_httpx_response({}, status_code=500)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert not score.passed
+            assert score.value == 0.0
+            assert "500" in score.reason
+
+    @pytest.mark.asyncio
+    async def test_timeout(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid", timeout=1.0)
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.side_effect = httpx.TimeoutException("Timeout")
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert not score.passed
+            assert score.value == 0.0
+            assert "timed out" in score.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid")
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.side_effect = httpx.ConnectError("Connection refused")
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert not score.passed
+            assert score.value == 0.0
+            assert "failed" in score.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_response(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", response_key="is_valid")
+
+        resp = httpx.Response(status_code=200, content=b"not json")
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = await metric.a_measure(ec)
+            assert not score.passed
+            assert score.value == 0.0
+            assert "Invalid response format" in score.reason
+
+
+@pytest.mark.unit
+class TestWebhookMetricSyncMeasure:
+    def test_sync_measure_calls_async(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", use_status_code=True)
+
+        resp = _mock_httpx_response({}, status_code=200)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            score = metric.measure(ec)
+            assert score.passed
+            assert score.value == 1.0
+
+
+@pytest.mark.unit
+class TestWebhookMetricCustomHeaders:
+    @pytest.mark.asyncio
+    async def test_custom_headers(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(
+            url="http://example.com/validate",
+            headers={"Authorization": "Bearer token123", "X-Custom": "value"},
+            use_status_code=True,
+        )
+
+        resp = _mock_httpx_response({}, status_code=200)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            await metric.a_measure(ec)
+
+            call_kwargs = mock_client.request.call_args[1]
+            assert call_kwargs["headers"]["Authorization"] == "Bearer token123"
+            assert call_kwargs["headers"]["X-Custom"] == "value"
+
+
+@pytest.mark.unit
+class TestWebhookMetricCustomMethod:
+    @pytest.mark.asyncio
+    async def test_custom_method(self):
+        ec = EvalCase(input="test input", output="test output", expected="test expected")
+        metric = WebhookMetric(url="http://example.com/validate", method="PUT", use_status_code=True)
+
+        resp = _mock_httpx_response({}, status_code=200)
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.request.return_value = resp
+            mock_cls.return_value = mock_client
+
+            await metric.a_measure(ec)
+
+            call_args = mock_client.request.call_args[1]
+            assert call_args["method"] == "PUT"


### PR DESCRIPTION
## Summary
- Adds `WebhookMetric` to validate LLM outputs by calling an external HTTP endpoint
- Three explicit response handling modes: `response_key` (boolean field in JSON), `use_status_code` (2xx = pass), `response_fn` (full custom parser)
- Supports custom payloads via `payload_fn`, auth headers, configurable timeout, and optional `score_key` for float values
- Inspired by promptfoo's webhook assertion pattern — no magic, user must explicitly configure response interpretation

## Test plan
- [x] 26 unit tests covering all response modes, error handling, payloads, headers, and methods
- [x] Live integration tests against httpbin.org (status codes, echo, timeout, auth headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)