### PR TITLE
feat: add harness-evals recommend command for prompt, endpoint, and traces

### DIFF
--- a/src/harness_evals/cli.py
+++ b/src/harness_evals/cli.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import os
 import sys
 import uuid
 from pathlib import Path
 
 from harness_evals.errors import BaselineRegressionError, HarnessEvalsError
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER_ENV_VARS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -42,14 +51,17 @@ def main(argv: list[str] | None = None) -> int:
         help="Custom glob pattern (default: **/*.eval.yaml for YAML configs, **/eval_*.py for Python eval files)",
     )
 
-
     # --- recommend ---
     recommend_parser = sub.add_parser("recommend", help="Recommend evals for a prompt, endpoint, or traces")
     recommend_parser.add_argument("--prompt", default=None, help="Path to a prompt file or prompt text")
     recommend_parser.add_argument("--endpoint", default=None, help="HTTP endpoint URL to evaluate")
     recommend_parser.add_argument("--traces", default=None, help="Path to a traces file (JSONL)")
-    recommend_parser.add_argument("--api-key", default=None, help="LLM provider API key (or set ANTHROPIC_API_KEY/OPENAI_API_KEY env var)")
-    recommend_parser.add_argument("--provider", default="anthropic", choices=["anthropic", "openai"], help="LLM provider")
+    recommend_parser.add_argument(
+        "--api-key", default=None, help="LLM provider API key (or set ANTHROPIC_API_KEY/OPENAI_API_KEY env var)"
+    )
+    recommend_parser.add_argument(
+        "--provider", default="anthropic", choices=["anthropic", "openai"], help="LLM provider"
+    )
     recommend_parser.add_argument("--model", default=None, help="Model name override")
     recommend_parser.add_argument("-o", "--output", default=".", help="Output directory for EvalConfig and goldens")
 
@@ -59,48 +71,9 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 0
 
-
-
     try:
         if args.command == "recommend":
-            import os
-            from harness_evals.recommender.scenarios import load_scenario
-            from harness_evals.recommender.engine import recommend
-            from harness_evals.recommender.output import write_outputs, print_recommendation
-
-            api_key = args.api_key
-            if not api_key:
-                if args.provider == "anthropic":
-                    api_key = os.environ.get("ANTHROPIC_API_KEY")
-                elif args.provider == "openai":
-                    api_key = os.environ.get("OPENAI_API_KEY")
-            if not api_key:
-                raise ValueError(
-                    f"No API key provided. Pass --api-key or set "
-                    f"{'ANTHROPIC_API_KEY' if args.provider == 'anthropic' else 'OPENAI_API_KEY'} env var."
-                )
-
-            scenario = load_scenario(
-                prompt=getattr(args, "prompt", None),
-                endpoint=getattr(args, "endpoint", None),
-                traces=getattr(args, "traces", None),
-            )
-            recommendation = recommend(
-                scenario=scenario,
-                api_key=api_key,
-                provider=args.provider,
-                model=getattr(args, "model", None),
-            )
-            print_recommendation(recommendation)
-            config_path, goldens_path = write_outputs(
-                recommendation,
-                output_dir=args.output,
-                provider=args.provider,
-            )
-            print(f"EvalConfig written to: {config_path}")
-            print(f"Goldens written to:    {goldens_path}")
-            return 0
-
+            return _cmd_recommend(args)
         if args.command == "run":
             return _cmd_run(args)
         if args.command == "import":
@@ -123,6 +96,49 @@ def main(argv: list[str] | None = None) -> int:
             raise
         return 2
 
+    return 0
+
+
+def _cmd_recommend(args: argparse.Namespace) -> int:
+    from harness_evals._async_compat import _run_async
+    from harness_evals.config.runner import build_llm
+    from harness_evals.config.schema import ModelSpec
+    from harness_evals.recommender.engine import recommend
+    from harness_evals.recommender.output import default_model, print_recommendation, write_outputs
+    from harness_evals.recommender.scenarios import load_scenario
+
+    env_var = _PROVIDER_ENV_VARS.get(args.provider)
+    api_key = args.api_key or (os.environ.get(env_var) if env_var else None)
+    if not api_key:
+        raise ValueError(f"No API key provided. Pass --api-key or set {env_var or 'the provider API key'} env var.")
+
+    scenario = load_scenario(
+        prompt=getattr(args, "prompt", None),
+        endpoint=getattr(args, "endpoint", None),
+        traces=getattr(args, "traces", None),
+    )
+
+    # The CLI owns LLM construction — build_llm resolves the provider class and
+    # wires the api_key into the ModelSpec params.
+    model_name = args.model or default_model(args.provider)
+    logger.info("Building %s LLM for recommendation (model=%s)", args.provider, model_name)
+    model_spec = ModelSpec(
+        provider=args.provider,
+        name=model_name,
+        params={"api_key": api_key},
+    )
+    llm = build_llm(model_spec)
+
+    recommendation = _run_async(recommend(scenario=scenario, llm=llm))
+    print_recommendation(recommendation)
+    config_path, goldens_path = write_outputs(
+        recommendation,
+        output_dir=args.output,
+        provider=args.provider,
+        model=getattr(args, "model", None),
+    )
+    print(f"EvalConfig written to: {config_path}")
+    print(f"Goldens written to:    {goldens_path}")
     return 0
 
 

--- a/src/harness_evals/cli.py
+++ b/src/harness_evals/cli.py
@@ -42,11 +42,50 @@ def main(argv: list[str] | None = None) -> int:
         help="Custom glob pattern (default: **/*.eval.yaml for YAML configs, **/eval_*.py for Python eval files)",
     )
 
+
+    # --- recommend ---
+    recommend_parser = sub.add_parser("recommend", help="Recommend evals for a prompt, endpoint, or traces")
+    recommend_parser.add_argument("--prompt", default=None, help="Path to a prompt file or prompt text")
+    recommend_parser.add_argument("--endpoint", default=None, help="HTTP endpoint URL to evaluate")
+    recommend_parser.add_argument("--traces", default=None, help="Path to a traces file (JSONL)")
+    recommend_parser.add_argument("--api-key", required=True, help="LLM provider API key")
+    recommend_parser.add_argument("--provider", default="anthropic", choices=["anthropic", "openai"], help="LLM provider")
+    recommend_parser.add_argument("--model", default=None, help="Model name override")
+    recommend_parser.add_argument("-o", "--output", default=".", help="Output directory for EvalConfig and goldens")
+
     args = parser.parse_args(argv)
 
     if args.command is None:
         parser.print_help()
         return 0
+
+    if args.command == "recommend":
+        from harness_evals.recommender.scenarios import load_scenario
+        from harness_evals.recommender.engine import recommend
+        from harness_evals.recommender.output import write_outputs, print_recommendation
+        try:
+            scenario = load_scenario(
+                prompt=getattr(args, "prompt", None),
+                endpoint=getattr(args, "endpoint", None),
+                traces=getattr(args, "traces", None),
+            )
+            recommendation = recommend(
+                scenario=scenario,
+                api_key=args.api_key,
+                provider=args.provider,
+                model=getattr(args, "model", None),
+            )
+            print_recommendation(recommendation)
+            config_path, goldens_path = write_outputs(recommendation, output_dir=args.output)
+            print(f"EvalConfig written to: {config_path}")
+            print(f"Goldens written to:    {goldens_path}")
+            return 0
+        except Exception as e:
+            import sys
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+
 
     try:
         if args.command == "run":

--- a/src/harness_evals/cli.py
+++ b/src/harness_evals/cli.py
@@ -48,7 +48,7 @@ def main(argv: list[str] | None = None) -> int:
     recommend_parser.add_argument("--prompt", default=None, help="Path to a prompt file or prompt text")
     recommend_parser.add_argument("--endpoint", default=None, help="HTTP endpoint URL to evaluate")
     recommend_parser.add_argument("--traces", default=None, help="Path to a traces file (JSONL)")
-    recommend_parser.add_argument("--api-key", required=True, help="LLM provider API key")
+    recommend_parser.add_argument("--api-key", default=None, help="LLM provider API key (or set ANTHROPIC_API_KEY/OPENAI_API_KEY env var)")
     recommend_parser.add_argument("--provider", default="anthropic", choices=["anthropic", "openai"], help="LLM provider")
     recommend_parser.add_argument("--model", default=None, help="Model name override")
     recommend_parser.add_argument("-o", "--output", default=".", help="Output directory for EvalConfig and goldens")
@@ -59,11 +59,27 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 0
 
-    if args.command == "recommend":
-        from harness_evals.recommender.scenarios import load_scenario
-        from harness_evals.recommender.engine import recommend
-        from harness_evals.recommender.output import write_outputs, print_recommendation
-        try:
+
+
+    try:
+        if args.command == "recommend":
+            import os
+            from harness_evals.recommender.scenarios import load_scenario
+            from harness_evals.recommender.engine import recommend
+            from harness_evals.recommender.output import write_outputs, print_recommendation
+
+            api_key = args.api_key
+            if not api_key:
+                if args.provider == "anthropic":
+                    api_key = os.environ.get("ANTHROPIC_API_KEY")
+                elif args.provider == "openai":
+                    api_key = os.environ.get("OPENAI_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    f"No API key provided. Pass --api-key or set "
+                    f"{'ANTHROPIC_API_KEY' if args.provider == 'anthropic' else 'OPENAI_API_KEY'} env var."
+                )
+
             scenario = load_scenario(
                 prompt=getattr(args, "prompt", None),
                 endpoint=getattr(args, "endpoint", None),
@@ -71,23 +87,20 @@ def main(argv: list[str] | None = None) -> int:
             )
             recommendation = recommend(
                 scenario=scenario,
-                api_key=args.api_key,
+                api_key=api_key,
                 provider=args.provider,
                 model=getattr(args, "model", None),
             )
             print_recommendation(recommendation)
-            config_path, goldens_path = write_outputs(recommendation, output_dir=args.output)
+            config_path, goldens_path = write_outputs(
+                recommendation,
+                output_dir=args.output,
+                provider=args.provider,
+            )
             print(f"EvalConfig written to: {config_path}")
             print(f"Goldens written to:    {goldens_path}")
             return 0
-        except Exception as e:
-            import sys
-            print(f"Error: {e}", file=sys.stderr)
-            return 1
 
-
-
-    try:
         if args.command == "run":
             return _cmd_run(args)
         if args.command == "import":

--- a/src/harness_evals/recommender/__init__.py
+++ b/src/harness_evals/recommender/__init__.py
@@ -1,5 +1,5 @@
 """Eval Recommender — suggest metrics, goldens, and EvalConfig for any agent input."""
 
-from harness_evals.recommender.engine import recommend
+from harness_evals.recommender.engine import RECOMMENDATION_SCHEMA, recommend
 
-__all__ = ["recommend"]
+__all__ = ["recommend", "RECOMMENDATION_SCHEMA"]

--- a/src/harness_evals/recommender/__init__.py
+++ b/src/harness_evals/recommender/__init__.py
@@ -1,0 +1,5 @@
+"""Eval Recommender — suggest metrics, goldens, and EvalConfig for any agent input."""
+
+from harness_evals.recommender.engine import recommend
+
+__all__ = ["recommend"]

--- a/src/harness_evals/recommender/engine.py
+++ b/src/harness_evals/recommender/engine.py
@@ -90,7 +90,13 @@ def _recommend_anthropic(scenario: ScenarioInput, api_key: str, model: str) -> d
         if not response.content:
             raise ValueError("Anthropic returned empty response.")
         raw = response.content[0].text
-        return json.loads(raw)
+        clean = raw.strip()
+        if clean.startswith("```"):
+            clean = clean.split("```")[1]
+            if clean.startswith("json"):
+                clean = clean[4:]
+            clean = clean.strip()
+        return json.loads(clean)
 
     return _run_async(_call_anthropic())
 

--- a/src/harness_evals/recommender/engine.py
+++ b/src/harness_evals/recommender/engine.py
@@ -1,8 +1,13 @@
-"""Core recommender engine — calls an LLM with the full metric catalog and returns recommendations."""
+"""Core recommender engine — calls a ``BaseLLM`` with the full metric catalog and returns recommendations."""
 
 from __future__ import annotations
-import json
+
+import logging
+
+from harness_evals.llm.base import BaseLLM
 from harness_evals.recommender.scenarios import ScenarioInput
+
+logger = logging.getLogger(__name__)
 
 
 SYSTEM_PROMPT = """You are an AI evaluation expert with deep knowledge of the harness-evals metric catalog.
@@ -22,7 +27,7 @@ Return a JSON object with exactly these fields:
     {"name": "<exact catalog metric kind>", "dimension": "<dimension>", "rationale": "<why it applies>", "threshold": <float 0.0-1.0>}
   ],
   "recommended_dataset": [
-    {"input": "<realistic input>", "expected": "<expected output>", "context": null, "expected_tools": null, "expected_tool_calls": null, "metadata": {}, "tags": {}, "metric_tested": "<metric name>"}
+    {"input": "<realistic input>", "expected": "<expected output>", "context": null, "metric_tested": "<metric name>"}
   ],
   "recommended_actions": "<plain text next steps using harness-evals run>"
 }
@@ -35,8 +40,55 @@ Rules:
 """
 
 
+# JSON Schema for the recommendation response. Passed to ``generate_json()`` so
+# the provider enforces structured output. Kept strict-output friendly: no
+# free-form object properties, nullable fields expressed as type unions.
+RECOMMENDATION_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "dimensions_covered": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "dimension": {"type": "string"},
+                    "applies": {"type": "boolean"},
+                    "rationale": {"type": "string"},
+                },
+            },
+        },
+        "recommended_metrics": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "dimension": {"type": "string"},
+                    "rationale": {"type": "string"},
+                    "threshold": {"type": "number"},
+                },
+            },
+        },
+        "recommended_dataset": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "input": {"type": "string"},
+                    "expected": {"type": "string"},
+                    "context": {"type": ["array", "null"], "items": {"type": "string"}},
+                    "metric_tested": {"type": "string"},
+                },
+            },
+        },
+        "recommended_actions": {"type": "string"},
+    },
+}
+
+
 def _build_catalog_text() -> str:
     from harness_evals.catalog import catalog
+
     entries = catalog()
     lines = []
     for entry in entries:
@@ -57,76 +109,29 @@ Available metrics in the harness-evals catalog:
 Return your recommendation as a JSON object following the schema in your instructions."""
 
 
-def recommend(
-    scenario: ScenarioInput,
-    api_key: str,
-    provider: str = "anthropic",
-    model: str | None = None,
-) -> dict:
-    if provider == "anthropic":
-        return _recommend_anthropic(scenario, api_key, model or "claude-sonnet-4-20250514")
-    elif provider == "openai":
-        return _recommend_openai(scenario, api_key, model or "gpt-4o")
-    else:
-        raise ValueError(f"Unsupported provider: {provider}. Choose 'anthropic' or 'openai'.")
+async def recommend(scenario: ScenarioInput, llm: BaseLLM) -> dict:
+    """Ask *llm* to recommend evals for *scenario*.
 
+    The CLI is responsible for building *llm* via ``build_llm(ModelSpec(...))``,
+    so this function stays provider-agnostic and works with any ``BaseLLM``.
+    """
 
-def _recommend_anthropic(scenario: ScenarioInput, api_key: str, model: str) -> dict:
-    try:
-        import anthropic
-    except ImportError:
-        raise ImportError("Install anthropic: pip install anthropic")
-
-    from harness_evals._async_compat import _run_async
-
-    async def _call_anthropic():
-        client = anthropic.AsyncAnthropic(api_key=api_key)
-        response = await client.messages.create(
-            model=model,
-            max_tokens=4096,
-            system=SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": _build_user_prompt(scenario)}],
-        )
-        if not response.content:
-            raise ValueError("Anthropic returned empty response.")
-        raw = response.content[0].text
-        clean = raw.strip()
-        if clean.startswith("```"):
-            clean = clean.split("```")[1]
-            if clean.startswith("json"):
-                clean = clean[4:]
-            clean = clean.strip()
-        return json.loads(clean)
-
-    return _run_async(_call_anthropic())
-
-
-def _recommend_openai(scenario: ScenarioInput, api_key: str, model: str) -> dict:
-    try:
-        import openai
-    except ImportError:
-        raise ImportError("Install openai: pip install openai")
-
-    client = openai.OpenAI(api_key=api_key)
-    response = client.chat.completions.create(
-        model=model,
-        max_tokens=4096,
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": _build_user_prompt(scenario)},
-        ],
+    prompt = _build_user_prompt(scenario)
+    # Log the scenario type and prompt size only — never the prompt content
+    # (which may contain proprietary system prompts) or any credentials.
+    logger.info(
+        "Requesting recommendation: scenario_type=%s prompt_chars=%d",
+        scenario.type.value,
+        len(prompt),
     )
-    raw = response.choices[0].message.content
-    if not raw or not raw.strip():
-        raise ValueError(f"OpenAI returned empty response. Check your API key and account credits.")
-    # Strip markdown code fences if present
-    clean = raw.strip()
-    if clean.startswith("```"):
-        clean = clean.split("```")[1]
-        if clean.startswith("json"):
-            clean = clean[4:]
-        clean = clean.strip()
-    try:
-        return json.loads(clean)
-    except json.JSONDecodeError:
-        raise ValueError(f"OpenAI returned non-JSON response: {raw[:200]}")
+    recommendation = await llm.generate_json(
+        prompt,
+        RECOMMENDATION_SCHEMA,
+        system_prompt=SYSTEM_PROMPT,
+    )
+    logger.info(
+        "Received recommendation: metrics=%d dataset_cases=%d",
+        len(recommendation.get("recommended_metrics", [])),
+        len(recommendation.get("recommended_dataset", [])),
+    )
+    return recommendation

--- a/src/harness_evals/recommender/engine.py
+++ b/src/harness_evals/recommender/engine.py
@@ -64,7 +64,7 @@ def recommend(
     model: str | None = None,
 ) -> dict:
     if provider == "anthropic":
-        return _recommend_anthropic(scenario, api_key, model or "claude-sonnet-4-6")
+        return _recommend_anthropic(scenario, api_key, model or "claude-sonnet-4-20250514")
     elif provider == "openai":
         return _recommend_openai(scenario, api_key, model or "gpt-4o")
     else:
@@ -77,15 +77,22 @@ def _recommend_anthropic(scenario: ScenarioInput, api_key: str, model: str) -> d
     except ImportError:
         raise ImportError("Install anthropic: pip install anthropic")
 
-    client = anthropic.Anthropic(api_key=api_key)
-    response = client.messages.create(
-        model=model,
-        max_tokens=4096,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": _build_user_prompt(scenario)}],
-    )
-    raw = response.content[0].text
-    return json.loads(raw)
+    from harness_evals._async_compat import _run_async
+
+    async def _call_anthropic():
+        client = anthropic.AsyncAnthropic(api_key=api_key)
+        response = await client.messages.create(
+            model=model,
+            max_tokens=4096,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": _build_user_prompt(scenario)}],
+        )
+        if not response.content:
+            raise ValueError("Anthropic returned empty response.")
+        raw = response.content[0].text
+        return json.loads(raw)
+
+    return _run_async(_call_anthropic())
 
 
 def _recommend_openai(scenario: ScenarioInput, api_key: str, model: str) -> dict:

--- a/src/harness_evals/recommender/engine.py
+++ b/src/harness_evals/recommender/engine.py
@@ -1,0 +1,119 @@
+"""Core recommender engine — calls an LLM with the full metric catalog and returns recommendations."""
+
+from __future__ import annotations
+import json
+from harness_evals.recommender.scenarios import ScenarioInput
+
+
+SYSTEM_PROMPT = """You are an AI evaluation expert with deep knowledge of the harness-evals metric catalog.
+Given a description of what someone is building or has, recommend the right evaluations for it.
+
+You will be given:
+1. A scenario type: prompt (someone has a prompt), http_endpoint (someone has a deployed endpoint), or traces (someone has prior interaction traces)
+2. The scenario content
+3. The full list of available metrics from the harness-evals catalog
+
+Return a JSON object with exactly these fields:
+{
+  "dimensions_covered": [
+    {"dimension": "<name>", "applies": true/false, "rationale": "<one sentence>"}
+  ],
+  "recommended_metrics": [
+    {"name": "<exact catalog metric kind>", "dimension": "<dimension>", "rationale": "<why it applies>", "threshold": <float 0.0-1.0>}
+  ],
+  "recommended_dataset": [
+    {"input": "<realistic input>", "expected": "<expected output>", "context": null, "expected_tools": null, "expected_tool_calls": null, "metadata": {}, "tags": {}, "metric_tested": "<metric name>"}
+  ],
+  "recommended_actions": "<plain text next steps using harness-evals run>"
+}
+
+Rules:
+- Only use metric names that appear exactly in the provided catalog list.
+- Provide 3 to 5 entries in recommended_dataset.
+- Be specific to the scenario described, not generic.
+- Return only valid JSON, no prose before or after.
+"""
+
+
+def _build_catalog_text() -> str:
+    from harness_evals.catalog import catalog
+    entries = catalog()
+    lines = []
+    for entry in entries:
+        lines.append(f"- {entry.kind} ({entry.dimension.value}): {entry.description}")
+    return "\n".join(lines)
+
+
+def _build_user_prompt(scenario: ScenarioInput) -> str:
+    catalog_text = _build_catalog_text()
+    return f"""Scenario type: {scenario.type.value}
+
+Scenario content:
+{scenario.content}
+
+Available metrics in the harness-evals catalog:
+{catalog_text}
+
+Return your recommendation as a JSON object following the schema in your instructions."""
+
+
+def recommend(
+    scenario: ScenarioInput,
+    api_key: str,
+    provider: str = "anthropic",
+    model: str | None = None,
+) -> dict:
+    if provider == "anthropic":
+        return _recommend_anthropic(scenario, api_key, model or "claude-sonnet-4-6")
+    elif provider == "openai":
+        return _recommend_openai(scenario, api_key, model or "gpt-4o")
+    else:
+        raise ValueError(f"Unsupported provider: {provider}. Choose 'anthropic' or 'openai'.")
+
+
+def _recommend_anthropic(scenario: ScenarioInput, api_key: str, model: str) -> dict:
+    try:
+        import anthropic
+    except ImportError:
+        raise ImportError("Install anthropic: pip install anthropic")
+
+    client = anthropic.Anthropic(api_key=api_key)
+    response = client.messages.create(
+        model=model,
+        max_tokens=4096,
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": _build_user_prompt(scenario)}],
+    )
+    raw = response.content[0].text
+    return json.loads(raw)
+
+
+def _recommend_openai(scenario: ScenarioInput, api_key: str, model: str) -> dict:
+    try:
+        import openai
+    except ImportError:
+        raise ImportError("Install openai: pip install openai")
+
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model=model,
+        max_tokens=4096,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": _build_user_prompt(scenario)},
+        ],
+    )
+    raw = response.choices[0].message.content
+    if not raw or not raw.strip():
+        raise ValueError(f"OpenAI returned empty response. Check your API key and account credits.")
+    # Strip markdown code fences if present
+    clean = raw.strip()
+    if clean.startswith("```"):
+        clean = clean.split("```")[1]
+        if clean.startswith("json"):
+            clean = clean[4:]
+        clean = clean.strip()
+    try:
+        return json.loads(clean)
+    except json.JSONDecodeError:
+        raise ValueError(f"OpenAI returned non-JSON response: {raw[:200]}")

--- a/src/harness_evals/recommender/output.py
+++ b/src/harness_evals/recommender/output.py
@@ -1,83 +1,186 @@
-"""Format recommendation dict into EvalConfig YAML and goldens JSONL."""
+"""Turn a recommendation dict into a goldens dataset and an ``EvalConfig`` YAML file."""
 
 from __future__ import annotations
-import json
+
+import logging
 from pathlib import Path
 
+import yaml
 
-def write_outputs(recommendation: dict, output_dir: str = ".", provider: str = "openai") -> tuple[Path, Path]:
+from harness_evals.config.schema import (
+    BaselineSpec,
+    EvalConfig,
+    MetricSpec,
+    ModelSpec,
+    SinkSpec,
+    TargetSpec,
+)
+from harness_evals.core.golden import Golden
+from harness_evals.datasets.io import save_dataset
+from harness_evals.refs import ResourceRef
+
+logger = logging.getLogger(__name__)
+
+_DATASET_FILENAME = "recommended.goldens.jsonl"
+_CONFIG_FILENAME = "recommended.eval.yaml"
+
+_DEFAULT_MODELS = {
+    "anthropic": "claude-sonnet-4-20250514",
+    "openai": "gpt-4o",
+}
+
+
+def default_model(provider: str) -> str:
+    """Return the default model name for *provider*."""
+    return _DEFAULT_MODELS.get(provider, _DEFAULT_MODELS["anthropic"])
+
+
+def build_goldens(recommendation: dict) -> list[Golden]:
+    """Convert the recommended dataset entries into ``Golden`` objects."""
+
+    goldens: list[Golden] = []
+    for case in recommendation.get("recommended_dataset", []):
+        metadata = dict(case.get("metadata") or {})
+        metric_tested = case.get("metric_tested")
+        if metric_tested:
+            metadata["metric_tested"] = metric_tested
+        goldens.append(
+            Golden(
+                input=case.get("input", ""),
+                expected=case.get("expected", ""),
+                context=case.get("context"),
+                expected_tools=case.get("expected_tools"),
+                metadata=metadata or None,
+                tags=case.get("tags") or None,
+            )
+        )
+    return goldens
+
+
+def build_eval_config(
+    recommendation: dict,
+    *,
+    provider: str = "anthropic",
+    model: str | None = None,
+    dataset_filename: str = _DATASET_FILENAME,
+) -> EvalConfig:
+    """Assemble an ``EvalConfig`` from a recommendation using the config specs."""
+
+    model_name = model or default_model(provider)
+
+    metrics = [
+        MetricSpec(kind=m["name"], threshold=m.get("threshold")) for m in recommendation.get("recommended_metrics", [])
+    ]
+
+    return EvalConfig(
+        name="recommended-eval",
+        # Relative dataset path so the config is portable alongside the goldens file.
+        dataset=ResourceRef(source="local", id=dataset_filename),
+        target=TargetSpec(
+            type="prompt",
+            params={
+                "prompt": "./your-prompt.txt",
+                "model": {"provider": provider, "name": model_name},
+            },
+        ),
+        metrics=metrics,
+        judge_llm=ModelSpec(provider=provider, name=model_name),
+        sinks=[
+            SinkSpec(type="stdout"),
+            SinkSpec(type="json", params={"path": "./results.jsonl"}),
+        ],
+        baseline=BaselineSpec(store="json", path=".evals/baseline.json"),
+    )
+
+
+def _eval_config_to_dict(cfg: EvalConfig) -> dict:
+    """Serialize an ``EvalConfig`` (including judge_llm and baseline) to a YAML-ready dict."""
+
+    d: dict = {"name": cfg.name}
+
+    if cfg.dataset.source == "local":
+        d["dataset"] = cfg.dataset.id
+    else:
+        d["dataset"] = f"{cfg.dataset.source}://{cfg.dataset.id}" + (
+            f"@{cfg.dataset.version}" if cfg.dataset.version else ""
+        )
+
+    d["target"] = {"type": cfg.target.type, **cfg.target.params}
+
+    if cfg.judge_llm is not None:
+        d["judge_llm"] = {
+            "provider": cfg.judge_llm.provider,
+            "name": cfg.judge_llm.name,
+            **cfg.judge_llm.params,
+        }
+
+    d["metrics"] = []
+    for m in cfg.metrics:
+        if not m.params and m.threshold is None:
+            d["metrics"].append(m.kind)
+        else:
+            entry: dict = {"kind": m.kind}
+            if m.threshold is not None:
+                entry["threshold"] = m.threshold
+            if m.params:
+                entry["params"] = m.params
+            d["metrics"].append(entry)
+
+    if cfg.sinks:
+        d["sinks"] = []
+        for s in cfg.sinks:
+            if not s.params:
+                d["sinks"].append(s.type)
+            else:
+                d["sinks"].append({"type": s.type, **s.params})
+
+    if cfg.baseline is not None:
+        d["baseline"] = {"store": cfg.baseline.store, "path": cfg.baseline.path}
+
+    return d
+
+
+def write_outputs(
+    recommendation: dict,
+    output_dir: str = ".",
+    provider: str = "anthropic",
+    model: str | None = None,
+) -> tuple[Path, Path]:
+    """Write the goldens dataset and the ``EvalConfig`` YAML, returning their paths."""
+
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    goldens_path = out / "recommended.goldens.jsonl"
-    config_path = out / "recommended.eval.yaml"
+    goldens_path = out / _DATASET_FILENAME
+    config_path = out / _CONFIG_FILENAME
 
-    with goldens_path.open("w") as f:
-        for case in recommendation.get("recommended_dataset", []):
-            golden = {
-                "input": case.get("input", ""),
-                "expected": case.get("expected", ""),
-                "context": case.get("context"),
-                "expected_tools": case.get("expected_tools"),
-                "expected_tool_calls": case.get("expected_tool_calls"),
-                "metadata": case.get("metadata", {}),
-                "tags": case.get("tags", {}),
-            }
-            f.write(json.dumps(golden) + "\n")
+    goldens = build_goldens(recommendation)
+    save_dataset(goldens, str(goldens_path))
 
-    metrics_yaml = ""
-    for m in recommendation.get("recommended_metrics", []):
-        metrics_yaml += f"  - kind: {m['name']}\n"
-        metrics_yaml += f"    threshold: {m['threshold']}\n"
+    cfg = build_eval_config(recommendation, provider=provider, model=model)
+    config_yaml = yaml.dump(_eval_config_to_dict(cfg), default_flow_style=False, sort_keys=False)
+    config_path.write_text(config_yaml, encoding="utf-8")
 
-    config_yaml = f"""name: recommended-eval
-
-dataset: recommended.goldens.jsonl
-
-target:
-  type: prompt
-  # Replace with your actual target
-  prompt: ./your-prompt.txt
-  model:
-    provider: {provider}
-    name: {"claude-sonnet-4-20250514" if provider == "anthropic" else "gpt-4o"}
-
-judge_llm:
-  provider: {provider}
-  name: {"claude-sonnet-4-20250514" if provider == "anthropic" else "gpt-4o"}
-
-metrics:
-{metrics_yaml}
-sinks:
-  - stdout
-  - type: json
-    path: ./results.jsonl
-
-baseline:
-  store: json
-  path: .evals/baseline.json
-"""
-
-    config_path.write_text(config_yaml)
+    logger.info("Wrote %d goldens to %s and config to %s", len(goldens), goldens_path, config_path)
     return config_path, goldens_path
 
 
 def print_recommendation(recommendation: dict) -> None:
     print("\n=== DIMENSIONS COVERED ===\n")
     for d in recommendation.get("dimensions_covered", []):
-        applies = "YES" if d["applies"] else "no"
-        print(f"  {d['dimension']:<15} {applies:<5}  {d['rationale']}")
+        applies = "YES" if d.get("applies") else "no"
+        print(f"  {str(d.get('dimension', '')):<15} {applies:<5}  {d.get('rationale', '')}")
 
     print("\n=== RECOMMENDED METRICS ===\n")
     for m in recommendation.get("recommended_metrics", []):
-        print(f"  {m['name']:<35} threshold={m['threshold']}  ({m['dimension']})")
-        print(f"    → {m['rationale']}")
+        print(f"  {str(m.get('name', '')):<35} threshold={m.get('threshold')}  ({m.get('dimension', '')})")
+        print(f"    → {m.get('rationale', '')}")
 
     print("\n=== RECOMMENDED DATASET ===\n")
     for i, case in enumerate(recommendation.get("recommended_dataset", []), 1):
         print(f"  Test Case {i} (tests: {case.get('metric_tested', 'n/a')})")
-        inp = str(case.get('input', ''))[:80]
-        exp = str(case.get('expected', ''))[:80]
+        inp = str(case.get("input", ""))[:80]
+        exp = str(case.get("expected", ""))[:80]
         print(f"    Input:    {inp}")
         print(f"    Expected: {exp}")
 

--- a/src/harness_evals/recommender/output.py
+++ b/src/harness_evals/recommender/output.py
@@ -32,7 +32,7 @@ def write_outputs(recommendation: dict, output_dir: str = ".", provider: str = "
 
     config_yaml = f"""name: recommended-eval
 
-dataset: {goldens_path.resolve()}
+dataset: recommended.goldens.jsonl
 
 target:
   type: prompt
@@ -76,8 +76,8 @@ def print_recommendation(recommendation: dict) -> None:
     print("\n=== RECOMMENDED DATASET ===\n")
     for i, case in enumerate(recommendation.get("recommended_dataset", []), 1):
         print(f"  Test Case {i} (tests: {case.get('metric_tested', 'n/a')})")
-        inp = case['input'][:80]
-        exp = case['expected'][:80]
+        inp = str(case.get('input', ''))[:80]
+        exp = str(case.get('expected', ''))[:80]
         print(f"    Input:    {inp}")
         print(f"    Expected: {exp}")
 

--- a/src/harness_evals/recommender/output.py
+++ b/src/harness_evals/recommender/output.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 
-def write_outputs(recommendation: dict, output_dir: str = ".") -> tuple[Path, Path]:
+def write_outputs(recommendation: dict, output_dir: str = ".", provider: str = "openai") -> tuple[Path, Path]:
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
@@ -39,8 +39,12 @@ target:
   # Replace with your actual target
   prompt: ./your-prompt.txt
   model:
-    provider: openai
-    name: gpt-4o
+    provider: {provider}
+    name: {"claude-sonnet-4-20250514" if provider == "anthropic" else "gpt-4o"}
+
+judge_llm:
+  provider: {provider}
+  name: {"claude-sonnet-4-20250514" if provider == "anthropic" else "gpt-4o"}
 
 metrics:
 {metrics_yaml}

--- a/src/harness_evals/recommender/output.py
+++ b/src/harness_evals/recommender/output.py
@@ -1,0 +1,82 @@
+"""Format recommendation dict into EvalConfig YAML and goldens JSONL."""
+
+from __future__ import annotations
+import json
+from pathlib import Path
+
+
+def write_outputs(recommendation: dict, output_dir: str = ".") -> tuple[Path, Path]:
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    goldens_path = out / "recommended.goldens.jsonl"
+    config_path = out / "recommended.eval.yaml"
+
+    with goldens_path.open("w") as f:
+        for case in recommendation.get("recommended_dataset", []):
+            golden = {
+                "input": case.get("input", ""),
+                "expected": case.get("expected", ""),
+                "context": case.get("context"),
+                "expected_tools": case.get("expected_tools"),
+                "expected_tool_calls": case.get("expected_tool_calls"),
+                "metadata": case.get("metadata", {}),
+                "tags": case.get("tags", {}),
+            }
+            f.write(json.dumps(golden) + "\n")
+
+    metrics_yaml = ""
+    for m in recommendation.get("recommended_metrics", []):
+        metrics_yaml += f"  - kind: {m['name']}\n"
+        metrics_yaml += f"    threshold: {m['threshold']}\n"
+
+    config_yaml = f"""name: recommended-eval
+
+dataset: {goldens_path.resolve()}
+
+target:
+  type: prompt
+  # Replace with your actual target
+  prompt: ./your-prompt.txt
+  model:
+    provider: openai
+    name: gpt-4o
+
+metrics:
+{metrics_yaml}
+sinks:
+  - stdout
+  - type: json
+    path: ./results.jsonl
+
+baseline:
+  store: json
+  path: .evals/baseline.json
+"""
+
+    config_path.write_text(config_yaml)
+    return config_path, goldens_path
+
+
+def print_recommendation(recommendation: dict) -> None:
+    print("\n=== DIMENSIONS COVERED ===\n")
+    for d in recommendation.get("dimensions_covered", []):
+        applies = "YES" if d["applies"] else "no"
+        print(f"  {d['dimension']:<15} {applies:<5}  {d['rationale']}")
+
+    print("\n=== RECOMMENDED METRICS ===\n")
+    for m in recommendation.get("recommended_metrics", []):
+        print(f"  {m['name']:<35} threshold={m['threshold']}  ({m['dimension']})")
+        print(f"    → {m['rationale']}")
+
+    print("\n=== RECOMMENDED DATASET ===\n")
+    for i, case in enumerate(recommendation.get("recommended_dataset", []), 1):
+        print(f"  Test Case {i} (tests: {case.get('metric_tested', 'n/a')})")
+        inp = case['input'][:80]
+        exp = case['expected'][:80]
+        print(f"    Input:    {inp}")
+        print(f"    Expected: {exp}")
+
+    print("\n=== RECOMMENDED ACTIONS ===\n")
+    print(f"  {recommendation.get('recommended_actions', '')}")
+    print()

--- a/src/harness_evals/recommender/scenarios.py
+++ b/src/harness_evals/recommender/scenarios.py
@@ -1,6 +1,7 @@
 """Normalize the three input scenarios into a common description for the recommender engine."""
 
 from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path

--- a/src/harness_evals/recommender/scenarios.py
+++ b/src/harness_evals/recommender/scenarios.py
@@ -1,0 +1,39 @@
+"""Normalize the three input scenarios into a common description for the recommender engine."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+class ScenarioType(str, Enum):
+    PROMPT = "prompt"
+    HTTP_ENDPOINT = "http_endpoint"
+    TRACES = "traces"
+
+
+@dataclass
+class ScenarioInput:
+    type: ScenarioType
+    content: str
+
+
+def load_scenario(
+    prompt: str | None = None,
+    endpoint: str | None = None,
+    traces: str | None = None,
+) -> ScenarioInput:
+    if sum(x is not None for x in [prompt, endpoint, traces]) != 1:
+        raise ValueError("Provide exactly one of --prompt, --endpoint, or --traces.")
+
+    if prompt is not None:
+        path = Path(prompt)
+        content = path.read_text() if path.exists() else prompt
+        return ScenarioInput(type=ScenarioType.PROMPT, content=content)
+
+    if endpoint is not None:
+        return ScenarioInput(type=ScenarioType.HTTP_ENDPOINT, content=endpoint)
+
+    path = Path(traces)
+    content = path.read_text() if path.exists() else traces
+    return ScenarioInput(type=ScenarioType.TRACES, content=content)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,3 +278,87 @@ class TestNoCommand:
     def test_no_args_prints_help(self, capsys) -> None:
         exit_code = main([])
         assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# recommend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCmdRecommend:
+    def test_recommend_prompt_success(self, tmp_path) -> None:
+        """Test successful recommend --prompt execution with recommend() mocked."""
+        mock_recommendation = {
+            "dimensions_covered": [{"dimension": "correctness", "applies": True, "rationale": "test"}],
+            "recommended_metrics": [{"name": "exact_match", "dimension": "correctness", "rationale": "test", "threshold": 0.8}],
+            "recommended_dataset": [
+                {
+                    "input": "test",
+                    "expected": "output",
+                    "context": None,
+                    "expected_tools": None,
+                    "expected_tool_calls": None,
+                    "metadata": {},
+                    "tags": {},
+                    "metric_tested": "exact_match",
+                }
+            ],
+            "recommended_actions": "Run harness-evals run recommended.eval.yaml",
+        }
+
+        with patch("harness_evals.recommender.engine.recommend", return_value=mock_recommendation):
+            exit_code = main(["recommend", "--prompt", "You are helpful", "--api-key", "fake-key", "-o", str(tmp_path)])
+
+        assert exit_code == 0
+        assert (tmp_path / "recommended.eval.yaml").exists()
+        assert (tmp_path / "recommended.goldens.jsonl").exists()
+
+    def test_recommend_anthropic_api_key_env_fallback(self, tmp_path, monkeypatch) -> None:
+        """Test ANTHROPIC_API_KEY environment variable fallback."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-anthropic-key")
+
+        mock_recommendation = {
+            "dimensions_covered": [],
+            "recommended_metrics": [],
+            "recommended_dataset": [],
+            "recommended_actions": "test",
+        }
+
+        with patch("harness_evals.recommender.engine.recommend", return_value=mock_recommendation) as mock_recommend:
+            exit_code = main(["recommend", "--prompt", "test", "--provider", "anthropic", "-o", str(tmp_path)])
+
+        assert exit_code == 0
+        # Verify recommend was called with the env var API key
+        mock_recommend.assert_called_once()
+        assert mock_recommend.call_args[1]["api_key"] == "fake-anthropic-key"
+
+    def test_recommend_openai_api_key_env_fallback(self, tmp_path, monkeypatch) -> None:
+        """Test OPENAI_API_KEY environment variable fallback."""
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-openai-key")
+
+        mock_recommendation = {
+            "dimensions_covered": [],
+            "recommended_metrics": [],
+            "recommended_dataset": [],
+            "recommended_actions": "test",
+        }
+
+        with patch("harness_evals.recommender.engine.recommend", return_value=mock_recommendation) as mock_recommend:
+            exit_code = main(["recommend", "--prompt", "test", "--provider", "openai", "-o", str(tmp_path)])
+
+        assert exit_code == 0
+        # Verify recommend was called with the env var API key
+        mock_recommend.assert_called_once()
+        assert mock_recommend.call_args[1]["api_key"] == "fake-openai-key"
+
+    def test_recommend_missing_api_key_returns_exit_code_2(self, tmp_path) -> None:
+        """Test missing API key returns exit code 2."""
+        exit_code = main(["recommend", "--prompt", "test", "--provider", "anthropic", "-o", str(tmp_path)])
+        assert exit_code == 2
+
+    def test_recommend_verbose_reraises_exception(self, tmp_path) -> None:
+        """Test --verbose reraises an exception."""
+        with patch("harness_evals.recommender.engine.recommend", side_effect=ValueError("Test error")):
+            with pytest.raises(ValueError, match="Test error"):
+                main(["--verbose", "recommend", "--prompt", "test", "--api-key", "fake-key", "-o", str(tmp_path)])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from harness_evals.cli import main
+from harness_evals.llm.base import BaseLLM
 
 _MINIMAL_CONFIG = """\
 name: cli-test
@@ -285,80 +286,103 @@ class TestNoCommand:
 # ---------------------------------------------------------------------------
 
 
+_MOCK_RECOMMENDATION = {
+    "dimensions_covered": [{"dimension": "correctness", "applies": True, "rationale": "test"}],
+    "recommended_metrics": [{"name": "exact_match", "dimension": "correctness", "rationale": "test", "threshold": 0.8}],
+    "recommended_dataset": [
+        {
+            "input": "test",
+            "expected": "output",
+            "context": None,
+            "metric_tested": "exact_match",
+        }
+    ],
+    "recommended_actions": "Run harness-evals run recommended.eval.yaml",
+}
+
+
+class _FakeLLM(BaseLLM):
+    """A BaseLLM that returns a canned recommendation from generate_json."""
+
+    def __init__(self, response: dict) -> None:
+        self._response = response
+
+    async def generate(self, prompt: str, **kwargs) -> str:
+        return ""
+
+    async def generate_json(self, prompt: str, schema: dict, **kwargs) -> dict:
+        return self._response
+
+
 @pytest.mark.unit
 class TestCmdRecommend:
     def test_recommend_prompt_success(self, tmp_path) -> None:
-        """Test successful recommend --prompt execution with recommend() mocked."""
-        mock_recommendation = {
-            "dimensions_covered": [{"dimension": "correctness", "applies": True, "rationale": "test"}],
-            "recommended_metrics": [{"name": "exact_match", "dimension": "correctness", "rationale": "test", "threshold": 0.8}],
-            "recommended_dataset": [
-                {
-                    "input": "test",
-                    "expected": "output",
-                    "context": None,
-                    "expected_tools": None,
-                    "expected_tool_calls": None,
-                    "metadata": {},
-                    "tags": {},
-                    "metric_tested": "exact_match",
-                }
-            ],
-            "recommended_actions": "Run harness-evals run recommended.eval.yaml",
-        }
+        """recommend --prompt builds an LLM, calls generate_json, and writes outputs."""
+        fake_llm = _FakeLLM(_MOCK_RECOMMENDATION)
 
-        with patch("harness_evals.recommender.engine.recommend", return_value=mock_recommendation):
+        with patch("harness_evals.config.runner.build_llm", return_value=fake_llm):
             exit_code = main(["recommend", "--prompt", "You are helpful", "--api-key", "fake-key", "-o", str(tmp_path)])
 
         assert exit_code == 0
         assert (tmp_path / "recommended.eval.yaml").exists()
         assert (tmp_path / "recommended.goldens.jsonl").exists()
 
+    def test_recommend_builds_llm_with_model_spec(self, tmp_path) -> None:
+        """The CLI creates the LLM through build_llm(ModelSpec) with provider + api_key."""
+        fake_llm = _FakeLLM(_MOCK_RECOMMENDATION)
+
+        with patch("harness_evals.config.runner.build_llm", return_value=fake_llm) as mock_build:
+            exit_code = main(
+                ["recommend", "--prompt", "test", "--provider", "openai", "--api-key", "fake-key", "-o", str(tmp_path)]
+            )
+
+        assert exit_code == 0
+        mock_build.assert_called_once()
+        spec = mock_build.call_args[0][0]
+        assert spec.provider == "openai"
+        assert spec.name == "gpt-4o"
+        assert spec.params["api_key"] == "fake-key"
+
     def test_recommend_anthropic_api_key_env_fallback(self, tmp_path, monkeypatch) -> None:
-        """Test ANTHROPIC_API_KEY environment variable fallback."""
+        """ANTHROPIC_API_KEY environment variable is used when --api-key is absent."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-anthropic-key")
+        fake_llm = _FakeLLM(_MOCK_RECOMMENDATION)
 
-        mock_recommendation = {
-            "dimensions_covered": [],
-            "recommended_metrics": [],
-            "recommended_dataset": [],
-            "recommended_actions": "test",
-        }
-
-        with patch("harness_evals.recommender.engine.recommend", return_value=mock_recommendation) as mock_recommend:
+        with patch("harness_evals.config.runner.build_llm", return_value=fake_llm) as mock_build:
             exit_code = main(["recommend", "--prompt", "test", "--provider", "anthropic", "-o", str(tmp_path)])
 
         assert exit_code == 0
-        # Verify recommend was called with the env var API key
-        mock_recommend.assert_called_once()
-        assert mock_recommend.call_args[1]["api_key"] == "fake-anthropic-key"
+        spec = mock_build.call_args[0][0]
+        assert spec.provider == "anthropic"
+        assert spec.name == "claude-sonnet-4-20250514"
+        assert spec.params["api_key"] == "fake-anthropic-key"
 
     def test_recommend_openai_api_key_env_fallback(self, tmp_path, monkeypatch) -> None:
-        """Test OPENAI_API_KEY environment variable fallback."""
+        """OPENAI_API_KEY environment variable is used when --api-key is absent."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "fake-openai-key")
+        fake_llm = _FakeLLM(_MOCK_RECOMMENDATION)
 
-        mock_recommendation = {
-            "dimensions_covered": [],
-            "recommended_metrics": [],
-            "recommended_dataset": [],
-            "recommended_actions": "test",
-        }
-
-        with patch("harness_evals.recommender.engine.recommend", return_value=mock_recommendation) as mock_recommend:
+        with patch("harness_evals.config.runner.build_llm", return_value=fake_llm) as mock_build:
             exit_code = main(["recommend", "--prompt", "test", "--provider", "openai", "-o", str(tmp_path)])
 
         assert exit_code == 0
-        # Verify recommend was called with the env var API key
-        mock_recommend.assert_called_once()
-        assert mock_recommend.call_args[1]["api_key"] == "fake-openai-key"
+        spec = mock_build.call_args[0][0]
+        assert spec.provider == "openai"
+        assert spec.params["api_key"] == "fake-openai-key"
 
-    def test_recommend_missing_api_key_returns_exit_code_2(self, tmp_path) -> None:
-        """Test missing API key returns exit code 2."""
+    def test_recommend_missing_api_key_returns_exit_code_2(self, tmp_path, monkeypatch) -> None:
+        """Missing API key returns exit code 2."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         exit_code = main(["recommend", "--prompt", "test", "--provider", "anthropic", "-o", str(tmp_path)])
         assert exit_code == 2
 
     def test_recommend_verbose_reraises_exception(self, tmp_path) -> None:
-        """Test --verbose reraises an exception."""
-        with patch("harness_evals.recommender.engine.recommend", side_effect=ValueError("Test error")):
-            with pytest.raises(ValueError, match="Test error"):
-                main(["--verbose", "recommend", "--prompt", "test", "--api-key", "fake-key", "-o", str(tmp_path)])
+        """--verbose reraises an exception instead of swallowing it."""
+        with (
+            patch("harness_evals.config.runner.build_llm", side_effect=ValueError("Test error")),
+            pytest.raises(ValueError, match="Test error"),
+        ):
+            main(["--verbose", "recommend", "--prompt", "test", "--api-key", "fake-key", "-o", str(tmp_path)])

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import json
 import pytest
+from unittest.mock import patch, MagicMock
 from harness_evals.recommender.scenarios import load_scenario, ScenarioType
 from harness_evals.recommender.output import write_outputs
 
@@ -32,18 +33,21 @@ MOCK_RECOMMENDATION = {
 }
 
 
+@pytest.mark.unit
 def test_load_scenario_prompt():
     s = load_scenario(prompt="You are a helpful assistant.")
     assert s.type == ScenarioType.PROMPT
     assert "helpful assistant" in s.content
 
 
+@pytest.mark.unit
 def test_load_scenario_endpoint():
     s = load_scenario(endpoint="http://localhost:8080/run")
     assert s.type == ScenarioType.HTTP_ENDPOINT
     assert s.content == "http://localhost:8080/run"
 
 
+@pytest.mark.unit
 def test_load_scenario_traces(tmp_path):
     traces_file = tmp_path / "traces.jsonl"
     traces_file.write_text('{"input": "hi", "output": "hello"}\n')
@@ -52,6 +56,7 @@ def test_load_scenario_traces(tmp_path):
     assert "hi" in s.content
 
 
+@pytest.mark.unit
 def test_load_scenario_requires_exactly_one():
     with pytest.raises(ValueError):
         load_scenario(prompt="a", endpoint="b")
@@ -59,8 +64,9 @@ def test_load_scenario_requires_exactly_one():
         load_scenario()
 
 
+@pytest.mark.unit
 def test_write_outputs(tmp_path):
-    config_path, goldens_path = write_outputs(MOCK_RECOMMENDATION, output_dir=str(tmp_path))
+    config_path, goldens_path = write_outputs(MOCK_RECOMMENDATION, output_dir=str(tmp_path), provider="anthropic")
     assert config_path.exists()
     assert goldens_path.exists()
     with goldens_path.open() as f:
@@ -75,9 +81,65 @@ def test_write_outputs(tmp_path):
     assert "metadata" in golden
     assert "tags" in golden
 
+    # Verify the generated YAML contains judge_llm with anthropic provider
+    config_text = config_path.read_text()
+    assert "judge_llm:" in config_text
+    assert "provider: anthropic" in config_text
+    assert "name: claude-sonnet-4-20250514" in config_text
 
+
+@pytest.mark.unit
 def test_recommended_metrics_use_catalog_names():
     from harness_evals.catalog import catalog
     catalog_kinds = {e.kind for e in catalog()}
     for m in MOCK_RECOMMENDATION["recommended_metrics"]:
         assert m["name"] in catalog_kinds, f"{m['name']} not in catalog"
+
+
+@pytest.mark.unit
+def test_recommend_openai_mocked():
+    from harness_evals.recommender.scenarios import ScenarioInput, ScenarioType
+    from harness_evals.recommender.engine import recommend
+
+    scenario = ScenarioInput(type=ScenarioType.PROMPT, content="You are a helpful assistant.")
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = json.dumps(MOCK_RECOMMENDATION)
+
+    with patch("harness_evals.recommender.engine._recommend_openai", return_value=MOCK_RECOMMENDATION):
+        result = recommend(scenario=scenario, api_key="fake-key", provider="openai")
+
+    assert "dimensions_covered" in result
+    assert "recommended_metrics" in result
+    assert "recommended_dataset" in result
+    assert "recommended_actions" in result
+
+
+@pytest.mark.unit
+def test_recommend_anthropic_mocked():
+    from harness_evals.recommender.scenarios import ScenarioInput, ScenarioType
+    from harness_evals.recommender.engine import recommend
+
+    scenario = ScenarioInput(type=ScenarioType.PROMPT, content="You are a helpful assistant.")
+
+    # Mock the AsyncAnthropic client and its awaitable messages.create() response
+    mock_content = MagicMock()
+    mock_content.text = json.dumps(MOCK_RECOMMENDATION)
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_content]
+
+    mock_client = MagicMock()
+
+    async def fake_create(*args, **kwargs):
+        return mock_response
+
+    mock_client.messages.create = fake_create
+
+    with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+        result = recommend(scenario=scenario, api_key="fake-key", provider="anthropic")
+
+    assert "dimensions_covered" in result
+    assert "recommended_metrics" in result
+    assert "recommended_dataset" in result
+    assert "recommended_actions" in result

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -1,12 +1,22 @@
 """Tests for the eval recommender module."""
 
 from __future__ import annotations
-import json
-import pytest
-from unittest.mock import patch, MagicMock
-from harness_evals.recommender.scenarios import load_scenario, ScenarioType
-from harness_evals.recommender.output import write_outputs
 
+import json
+
+import pytest
+import yaml
+
+from harness_evals.core.golden import Golden
+from harness_evals.llm.base import BaseLLM
+from harness_evals.recommender.engine import RECOMMENDATION_SCHEMA, recommend
+from harness_evals.recommender.output import (
+    build_eval_config,
+    build_goldens,
+    default_model,
+    write_outputs,
+)
+from harness_evals.recommender.scenarios import ScenarioInput, ScenarioType, load_scenario
 
 MOCK_RECOMMENDATION = {
     "dimensions_covered": [
@@ -22,15 +32,31 @@ MOCK_RECOMMENDATION = {
             "input": "What is 2+2?",
             "expected": "4",
             "context": None,
-            "expected_tools": None,
-            "expected_tool_calls": None,
-            "metadata": {},
-            "tags": {},
             "metric_tested": "exact_match",
         }
     ],
     "recommended_actions": "Run harness-evals run recommended.eval.yaml --fail-under 0.8",
 }
+
+
+class RecordingLLM(BaseLLM):
+    """A BaseLLM that records generate_json calls and returns a canned dict."""
+
+    def __init__(self, response: dict) -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    async def generate(self, prompt: str, **kwargs: object) -> str:
+        return ""
+
+    async def generate_json(self, prompt: str, schema: dict, **kwargs: object) -> dict:
+        self.calls.append({"prompt": prompt, "schema": schema, "kwargs": kwargs})
+        return self._response
+
+
+# ---------------------------------------------------------------------------
+# scenarios
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -64,82 +90,136 @@ def test_load_scenario_requires_exactly_one():
         load_scenario()
 
 
-@pytest.mark.unit
-def test_write_outputs(tmp_path):
-    config_path, goldens_path = write_outputs(MOCK_RECOMMENDATION, output_dir=str(tmp_path), provider="anthropic")
-    assert config_path.exists()
-    assert goldens_path.exists()
-    with goldens_path.open() as f:
-        lines = f.readlines()
-    assert len(lines) == 1
-    golden = json.loads(lines[0])
-    assert golden["input"] == "What is 2+2?"
-    assert golden["expected"] == "4"
-    assert "context" in golden
-    assert "expected_tools" in golden
-    assert "expected_tool_calls" in golden
-    assert "metadata" in golden
-    assert "tags" in golden
+# ---------------------------------------------------------------------------
+# engine — recommend() over a BaseLLM
+# ---------------------------------------------------------------------------
 
-    # Verify the generated YAML contains judge_llm with anthropic provider
-    config_text = config_path.read_text()
-    assert "judge_llm:" in config_text
-    assert "provider: anthropic" in config_text
-    assert "name: claude-sonnet-4-20250514" in config_text
+
+@pytest.mark.unit
+async def test_recommend_uses_base_llm_generate_json():
+    scenario = ScenarioInput(type=ScenarioType.PROMPT, content="You are a helpful assistant.")
+    llm = RecordingLLM(MOCK_RECOMMENDATION)
+
+    result = await recommend(scenario=scenario, llm=llm)
+
+    assert result == MOCK_RECOMMENDATION
+    assert len(llm.calls) == 1
+    call = llm.calls[0]
+    # Schema is passed through to generate_json.
+    assert call["schema"] is RECOMMENDATION_SCHEMA
+    # The system prompt is passed via kwargs (not the user prompt).
+    assert "system_prompt" in call["kwargs"]
+    assert "evaluation expert" in str(call["kwargs"]["system_prompt"])
+    # The user prompt contains the scenario content and the catalog.
+    assert "helpful assistant" in call["prompt"]
+    assert "exact_match" in call["prompt"]
+
+
+@pytest.mark.unit
+def test_recommend_schema_is_valid_json_schema():
+    assert RECOMMENDATION_SCHEMA["type"] == "object"
+    props = RECOMMENDATION_SCHEMA["properties"]
+    assert set(props) == {
+        "dimensions_covered",
+        "recommended_metrics",
+        "recommended_dataset",
+        "recommended_actions",
+    }
 
 
 @pytest.mark.unit
 def test_recommended_metrics_use_catalog_names():
     from harness_evals.catalog import catalog
+
     catalog_kinds = {e.kind for e in catalog()}
     for m in MOCK_RECOMMENDATION["recommended_metrics"]:
         assert m["name"] in catalog_kinds, f"{m['name']} not in catalog"
 
 
-@pytest.mark.unit
-def test_recommend_openai_mocked():
-    from harness_evals.recommender.scenarios import ScenarioInput, ScenarioType
-    from harness_evals.recommender.engine import recommend
-
-    scenario = ScenarioInput(type=ScenarioType.PROMPT, content="You are a helpful assistant.")
-
-    mock_response = MagicMock()
-    mock_response.choices[0].message.content = json.dumps(MOCK_RECOMMENDATION)
-
-    with patch("harness_evals.recommender.engine._recommend_openai", return_value=MOCK_RECOMMENDATION):
-        result = recommend(scenario=scenario, api_key="fake-key", provider="openai")
-
-    assert "dimensions_covered" in result
-    assert "recommended_metrics" in result
-    assert "recommended_dataset" in result
-    assert "recommended_actions" in result
+# ---------------------------------------------------------------------------
+# output — Golden + dataset + EvalConfig
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_recommend_anthropic_mocked():
-    from harness_evals.recommender.scenarios import ScenarioInput, ScenarioType
-    from harness_evals.recommender.engine import recommend
+def test_build_goldens_returns_golden_objects():
+    goldens = build_goldens(MOCK_RECOMMENDATION)
+    assert len(goldens) == 1
+    g = goldens[0]
+    assert isinstance(g, Golden)
+    assert g.input == "What is 2+2?"
+    assert g.expected == "4"
+    # metric_tested is folded into metadata.
+    assert g.metadata is not None
+    assert g.metadata["metric_tested"] == "exact_match"
 
-    scenario = ScenarioInput(type=ScenarioType.PROMPT, content="You are a helpful assistant.")
 
-    # Mock the AsyncAnthropic client and its awaitable messages.create() response
-    mock_content = MagicMock()
-    mock_content.text = json.dumps(MOCK_RECOMMENDATION)
+@pytest.mark.unit
+def test_build_eval_config_uses_specs():
+    from harness_evals.config.schema import EvalConfig
 
-    mock_response = MagicMock()
-    mock_response.content = [mock_content]
+    cfg = build_eval_config(MOCK_RECOMMENDATION, provider="anthropic")
+    assert isinstance(cfg, EvalConfig)
+    assert cfg.name == "recommended-eval"
+    # judge_llm present with the anthropic default model.
+    assert cfg.judge_llm is not None
+    assert cfg.judge_llm.provider == "anthropic"
+    assert cfg.judge_llm.name == default_model("anthropic")
+    # metrics carried across with thresholds.
+    kinds = {m.kind: m.threshold for m in cfg.metrics}
+    assert kinds == {"exact_match": 0.8, "latency": 0.7}
+    # relative dataset path.
+    assert cfg.dataset.source == "local"
+    assert cfg.dataset.id == "recommended.goldens.jsonl"
+    # baseline present.
+    assert cfg.baseline is not None
 
-    mock_client = MagicMock()
 
-    async def fake_create(*args, **kwargs):
-        return mock_response
+@pytest.mark.unit
+def test_write_outputs(tmp_path):
+    config_path, goldens_path = write_outputs(MOCK_RECOMMENDATION, output_dir=str(tmp_path), provider="anthropic")
+    assert config_path.exists()
+    assert goldens_path.exists()
 
-    mock_client.messages.create = fake_create
+    # Dataset is JSONL written via save_dataset — one Golden per line.
+    with goldens_path.open() as f:
+        lines = [line for line in f.read().splitlines() if line.strip()]
+    assert len(lines) == 1
+    golden = json.loads(lines[0])
+    assert golden["input"] == "What is 2+2?"
+    assert golden["expected"] == "4"
 
-    with patch("anthropic.AsyncAnthropic", return_value=mock_client):
-        result = recommend(scenario=scenario, api_key="fake-key", provider="anthropic")
+    # Config is valid YAML with judge_llm + anthropic provider + relative dataset.
+    config_data = yaml.safe_load(config_path.read_text())
+    assert config_data["dataset"] == "recommended.goldens.jsonl"
+    assert config_data["judge_llm"]["provider"] == "anthropic"
+    assert config_data["judge_llm"]["name"] == "claude-sonnet-4-20250514"
+    assert "baseline" in config_data
 
-    assert "dimensions_covered" in result
-    assert "recommended_metrics" in result
-    assert "recommended_dataset" in result
-    assert "recommended_actions" in result
+
+@pytest.mark.unit
+def test_write_outputs_config_reloads_as_eval_config(tmp_path):
+    from harness_evals.config.schema import load_config
+
+    config_path, _ = write_outputs(MOCK_RECOMMENDATION, output_dir=str(tmp_path), provider="openai")
+    cfg = load_config(str(config_path))
+    assert cfg.name == "recommended-eval"
+    assert cfg.judge_llm is not None
+    assert cfg.judge_llm.provider == "openai"
+    assert {m.kind for m in cfg.metrics} == {"exact_match", "latency"}
+
+
+@pytest.mark.unit
+def test_write_outputs_openai_provider(tmp_path):
+    config_path, _ = write_outputs(MOCK_RECOMMENDATION, output_dir=str(tmp_path), provider="openai")
+    config_data = yaml.safe_load(config_path.read_text())
+    assert config_data["judge_llm"]["provider"] == "openai"
+    assert config_data["judge_llm"]["name"] == "gpt-4o"
+
+
+@pytest.mark.unit
+def test_default_model():
+    assert default_model("anthropic") == "claude-sonnet-4-20250514"
+    assert default_model("openai") == "gpt-4o"
+    # Unknown providers fall back to the anthropic default.
+    assert default_model("unknown") == "claude-sonnet-4-20250514"

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -1,0 +1,83 @@
+"""Tests for the eval recommender module."""
+
+from __future__ import annotations
+import json
+import pytest
+from harness_evals.recommender.scenarios import load_scenario, ScenarioType
+from harness_evals.recommender.output import write_outputs
+
+
+MOCK_RECOMMENDATION = {
+    "dimensions_covered": [
+        {"dimension": "correctness", "applies": True, "rationale": "Agent must produce accurate output."},
+        {"dimension": "performance", "applies": True, "rationale": "Latency matters in production."},
+    ],
+    "recommended_metrics": [
+        {"name": "exact_match", "dimension": "correctness", "rationale": "Checks exact output.", "threshold": 0.8},
+        {"name": "latency", "dimension": "performance", "rationale": "Measures response time.", "threshold": 0.7},
+    ],
+    "recommended_dataset": [
+        {
+            "input": "What is 2+2?",
+            "expected": "4",
+            "context": None,
+            "expected_tools": None,
+            "expected_tool_calls": None,
+            "metadata": {},
+            "tags": {},
+            "metric_tested": "exact_match",
+        }
+    ],
+    "recommended_actions": "Run harness-evals run recommended.eval.yaml --fail-under 0.8",
+}
+
+
+def test_load_scenario_prompt():
+    s = load_scenario(prompt="You are a helpful assistant.")
+    assert s.type == ScenarioType.PROMPT
+    assert "helpful assistant" in s.content
+
+
+def test_load_scenario_endpoint():
+    s = load_scenario(endpoint="http://localhost:8080/run")
+    assert s.type == ScenarioType.HTTP_ENDPOINT
+    assert s.content == "http://localhost:8080/run"
+
+
+def test_load_scenario_traces(tmp_path):
+    traces_file = tmp_path / "traces.jsonl"
+    traces_file.write_text('{"input": "hi", "output": "hello"}\n')
+    s = load_scenario(traces=str(traces_file))
+    assert s.type == ScenarioType.TRACES
+    assert "hi" in s.content
+
+
+def test_load_scenario_requires_exactly_one():
+    with pytest.raises(ValueError):
+        load_scenario(prompt="a", endpoint="b")
+    with pytest.raises(ValueError):
+        load_scenario()
+
+
+def test_write_outputs(tmp_path):
+    config_path, goldens_path = write_outputs(MOCK_RECOMMENDATION, output_dir=str(tmp_path))
+    assert config_path.exists()
+    assert goldens_path.exists()
+    with goldens_path.open() as f:
+        lines = f.readlines()
+    assert len(lines) == 1
+    golden = json.loads(lines[0])
+    assert golden["input"] == "What is 2+2?"
+    assert golden["expected"] == "4"
+    assert "context" in golden
+    assert "expected_tools" in golden
+    assert "expected_tool_calls" in golden
+    assert "metadata" in golden
+    assert "tags" in golden
+
+
+def test_recommended_metrics_use_catalog_names():
+    from harness_evals.catalog import catalog
+    catalog_kinds = {e.kind for e in catalog()}
+    for m in MOCK_RECOMMENDATION["recommended_metrics"]:
+        assert m["name"] in catalog_kinds, f"{m['name']} not in catalog"


### PR DESCRIPTION
Adds a new harness-evals recommend CLI command that takes a prompt, HTTP endpoint, or traces file as input and returns recommended metrics, a golden dataset, and an EvalConfig YAML ready to run.

Changes:
- New src/harness_evals/recommender/ module with engine, scenarios, and output formatting
- New recommend subcommand added to CLI with --prompt, --endpoint, --traces, --api-key, --provider, --output flags
- Supports Anthropic and OpenAI as LLM providers
- Supports ANTHROPIC_API_KEY and OPENAI_API_KEY env var fallback
- Outputs recommended.eval.yaml and recommended.goldens.jsonl to specified output directory
- Uses AsyncAnthropic to match existing codebase patterns
- Adds judge_llm field to generated YAML for LLM-judged metrics
- 26 passing tests across tests/test_recommender.py and tests/test_cli.py