### PR TITLE
fix(schema_validation): parse markdown-fenced JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to harness-evals will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`schema_validation`**: tolerate markdown-fenced JSON (and common surrounding prose) when
+  parsing string outputs, matching typical LLM structured responses.
+
 ## [0.17.6]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harness-evals"
-version = "0.17.6"
+version = "0.17.7"
 description = "Open-source AI evaluation framework for LLM agents, prompts, and structured outputs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/harness_evals/metrics/structural/schema_validation.py
+++ b/src/harness_evals/metrics/structural/schema_validation.py
@@ -7,6 +7,7 @@ import jsonschema
 from harness_evals.core.eval_case import EvalCase
 from harness_evals.core.metric import BaseMetric, Dimension
 from harness_evals.core.score import Score
+from harness_evals.utils.json_output import parse_json_value
 
 
 class SchemaValidationMetric(BaseMetric):
@@ -24,15 +25,17 @@ class SchemaValidationMetric(BaseMetric):
         self.schema = schema
 
     def measure(self, eval_case: EvalCase) -> Score:
-        try:
-            data = json.loads(eval_case.output) if isinstance(eval_case.output, str) else eval_case.output
-        except (json.JSONDecodeError, TypeError) as e:
-            return Score(
-                name=self.name,
-                value=0.0,
-                threshold=self.threshold,
-                reason=f"Output could not be parsed as valid JSON ({e})",
-            )
+        if isinstance(eval_case.output, str):
+            data = parse_json_value(eval_case.output)
+            if data is None:
+                return Score(
+                    name=self.name,
+                    value=0.0,
+                    threshold=self.threshold,
+                    reason="Output could not be parsed as valid JSON",
+                )
+        else:
+            data = eval_case.output
 
         try:
             jsonschema.validate(instance=data, schema=self.schema)

--- a/src/harness_evals/metrics/structural/schema_validation.py
+++ b/src/harness_evals/metrics/structural/schema_validation.py
@@ -7,7 +7,7 @@ import jsonschema
 from harness_evals.core.eval_case import EvalCase
 from harness_evals.core.metric import BaseMetric, Dimension
 from harness_evals.core.score import Score
-from harness_evals.utils.json_output import parse_json_value
+from harness_evals.utils.json_output import json_parse_failure_reason, parse_json_value
 
 
 class SchemaValidationMetric(BaseMetric):
@@ -28,11 +28,12 @@ class SchemaValidationMetric(BaseMetric):
         if isinstance(eval_case.output, str):
             data = parse_json_value(eval_case.output)
             if data is None:
+                detail = json_parse_failure_reason(eval_case.output)
                 return Score(
                     name=self.name,
                     value=0.0,
                     threshold=self.threshold,
-                    reason="Output could not be parsed as valid JSON",
+                    reason=f"Output could not be parsed as valid JSON ({detail})",
                 )
         else:
             data = eval_case.output

--- a/src/harness_evals/utils/json_output.py
+++ b/src/harness_evals/utils/json_output.py
@@ -9,6 +9,76 @@ from typing import Any
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL | re.IGNORECASE)
 
 
+def _json_candidate_text(text: str) -> str:
+    """Strip outer whitespace and use fenced block content when present."""
+    stripped = text.strip()
+    fence = _JSON_FENCE_RE.search(stripped)
+    if fence:
+        return fence.group(1).strip()
+    return stripped
+
+
+def _decode_error_detail(exc: json.JSONDecodeError) -> str:
+    if exc.lineno and exc.colno:
+        return f"{exc.msg} (line {exc.lineno}, column {exc.colno})"
+    if exc.pos is not None:
+        return f"{exc.msg} (char {exc.pos})"
+    return exc.msg
+
+
+def json_parse_failure_reason(output: str | dict | list | None) -> str:
+    """Short explanation when :func:`parse_json_value` returns ``None``."""
+    if output is None:
+        return "output is empty or missing"
+    if isinstance(output, (dict, list)):
+        return "output is already structured data"
+    if not isinstance(output, str):
+        return f"output has unsupported type {type(output).__name__}"
+
+    text = output.strip()
+    if not text:
+        return "output is empty"
+
+    candidate = _json_candidate_text(text)
+    last_error: str | None = None
+
+    def note_error(exc: json.JSONDecodeError) -> None:
+        nonlocal last_error
+        last_error = _decode_error_detail(exc)
+
+    try:
+        json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        note_error(exc)
+    else:
+        return "unexpected parse failure"
+
+    if (candidate.startswith("{") or candidate.startswith("[")) and last_error:
+        return last_error
+
+    first_obj = text.find("{")
+    last_obj = text.rfind("}")
+    if first_obj != -1 and last_obj != -1 and last_obj > first_obj:
+        try:
+            json.loads(text[first_obj : last_obj + 1])
+        except json.JSONDecodeError as exc:
+            note_error(exc)
+        else:
+            return "unexpected parse failure"
+
+    first_arr = text.find("[")
+    last_arr = text.rfind("]")
+    if first_arr != -1 and last_arr != -1 and last_arr > first_arr:
+        try:
+            json.loads(text[first_arr : last_arr + 1])
+        except json.JSONDecodeError as exc:
+            note_error(exc)
+
+    if "{" not in text and "[" not in text:
+        return "no JSON object or array found in output"
+    return last_error or "could not decode JSON"
+
+
 def parse_json_value(output: str | dict | list | None) -> Any | None:
     """Best-effort parse of model output into a JSON value (object or array)."""
     if output is None:
@@ -22,9 +92,7 @@ def parse_json_value(output: str | dict | list | None) -> Any | None:
     if not text:
         return None
 
-    fence = _JSON_FENCE_RE.search(text)
-    if fence:
-        text = fence.group(1).strip()
+    text = _json_candidate_text(text)
 
     try:
         return json.loads(text)

--- a/src/harness_evals/utils/json_output.py
+++ b/src/harness_evals/utils/json_output.py
@@ -6,7 +6,7 @@ import json
 import re
 from typing import Any
 
-_JSON_FENCE_RE = re.compile(r"^```(?:json)?\s*\n?(.*?)\n?```\s*$", re.DOTALL | re.IGNORECASE)
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?\s*```", re.DOTALL | re.IGNORECASE)
 
 
 def parse_json_value(output: str | dict | list | None) -> Any | None:
@@ -22,7 +22,7 @@ def parse_json_value(output: str | dict | list | None) -> Any | None:
     if not text:
         return None
 
-    fence = _JSON_FENCE_RE.match(text)
+    fence = _JSON_FENCE_RE.search(text)
     if fence:
         text = fence.group(1).strip()
 

--- a/src/harness_evals/utils/json_output.py
+++ b/src/harness_evals/utils/json_output.py
@@ -1,0 +1,56 @@
+"""Parse JSON values from LLM text (markdown fences, surrounding prose)."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+_JSON_FENCE_RE = re.compile(r"^```(?:json)?\s*\n?(.*?)\n?```\s*$", re.DOTALL | re.IGNORECASE)
+
+
+def parse_json_value(output: str | dict | list | None) -> Any | None:
+    """Best-effort parse of model output into a JSON value (object or array)."""
+    if output is None:
+        return None
+    if isinstance(output, (dict, list)):
+        return output
+    if not isinstance(output, str):
+        return None
+
+    text = output.strip()
+    if not text:
+        return None
+
+    fence = _JSON_FENCE_RE.match(text)
+    if fence:
+        text = fence.group(1).strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    if text.startswith("{") or text.startswith("["):
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
+
+    first_obj = text.find("{")
+    last_obj = text.rfind("}")
+    if first_obj != -1 and last_obj != -1 and last_obj > first_obj:
+        try:
+            return json.loads(text[first_obj : last_obj + 1])
+        except json.JSONDecodeError:
+            pass
+
+    first_arr = text.find("[")
+    last_arr = text.rfind("]")
+    if first_arr != -1 and last_arr != -1 and last_arr > first_arr:
+        try:
+            return json.loads(text[first_arr : last_arr + 1])
+        except json.JSONDecodeError:
+            pass
+
+    return None

--- a/tests/metrics/test_structural.py
+++ b/tests/metrics/test_structural.py
@@ -54,3 +54,21 @@ class TestSchemaValidation:
         score = SchemaValidationMetric(schema=schema).measure(ec)
         assert not score.passed
         assert "Validation failed" in score.reason
+
+    def test_markdown_fenced_json_object(self):
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+        ec = EvalCase(
+            input="q",
+            output='```json\n{"name": "test"}\n```',
+        )
+        score = SchemaValidationMetric(schema=schema).measure(ec)
+        assert score.passed
+
+    def test_markdown_fenced_json_array(self):
+        schema = {
+            "type": "array",
+            "items": {"type": "object", "properties": {"title": {"type": "string"}}, "required": ["title"]},
+        }
+        ec = EvalCase(input="q", output='```json\n[{"title": "a"}]\n```')
+        score = SchemaValidationMetric(schema=schema).measure(ec)
+        assert score.passed

--- a/tests/metrics/test_structural.py
+++ b/tests/metrics/test_structural.py
@@ -72,3 +72,12 @@ class TestSchemaValidation:
         ec = EvalCase(input="q", output='```json\n[{"title": "a"}]\n```')
         score = SchemaValidationMetric(schema=schema).measure(ec)
         assert score.passed
+
+    def test_markdown_fenced_json_with_leading_prose(self):
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+        ec = EvalCase(
+            input="q",
+            output='Sure — here you go:\n```json\n{"name": "test"}\n```',
+        )
+        score = SchemaValidationMetric(schema=schema).measure(ec)
+        assert score.passed

--- a/tests/metrics/test_structural.py
+++ b/tests/metrics/test_structural.py
@@ -81,3 +81,31 @@ class TestSchemaValidation:
         )
         score = SchemaValidationMetric(schema=schema).measure(ec)
         assert score.passed
+
+    def test_markdown_fenced_json_fails_schema_not_parse(self):
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+        ec = EvalCase(
+            input="q",
+            output='```json\n{"count": 42}\n```',
+        )
+        score = SchemaValidationMetric(schema=schema).measure(ec)
+        assert not score.passed
+        assert score.value == 0.0
+        assert "Validation failed" in score.reason
+        assert "could not be parsed" not in score.reason.lower()
+
+    def test_unparseable_string_includes_detail(self):
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+        ec = EvalCase(input="q", output="not json at all")
+        score = SchemaValidationMetric(schema=schema).measure(ec)
+        assert not score.passed
+        assert "Output could not be parsed as valid JSON" in score.reason
+        assert "no JSON object or array found" in score.reason
+
+    def test_invalid_fenced_json_includes_decode_detail(self):
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+        ec = EvalCase(input="q", output="```json\n{not valid json}\n```")
+        score = SchemaValidationMetric(schema=schema).measure(ec)
+        assert not score.passed
+        assert "Output could not be parsed as valid JSON" in score.reason
+        assert "Expecting" in score.reason or "could not decode" in score.reason

--- a/tests/utils/test_json_output.py
+++ b/tests/utils/test_json_output.py
@@ -1,0 +1,20 @@
+"""Tests for json_output parsing helpers."""
+
+import pytest
+
+from harness_evals.utils.json_output import parse_json_value
+
+
+@pytest.mark.unit
+class TestParseJsonValue:
+    def test_plain_object(self):
+        assert parse_json_value('{"a": 1}') == {"a": 1}
+
+    def test_fenced_object(self):
+        assert parse_json_value('```json\n{"a": 1}\n```') == {"a": 1}
+
+    def test_fenced_array(self):
+        assert parse_json_value('```\n[1, 2]\n```') == [1, 2]
+
+    def test_passthrough_dict(self):
+        assert parse_json_value({"x": 1}) == {"x": 1}

--- a/tests/utils/test_json_output.py
+++ b/tests/utils/test_json_output.py
@@ -18,3 +18,7 @@ class TestParseJsonValue:
 
     def test_passthrough_dict(self):
         assert parse_json_value({"x": 1}) == {"x": 1}
+
+    def test_prose_before_fenced_object(self):
+        text = "Here is the JSON:\n```json\n{\"a\": 1}\n```"
+        assert parse_json_value(text) == {"a": 1}

--- a/tests/utils/test_json_output.py
+++ b/tests/utils/test_json_output.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from harness_evals.utils.json_output import parse_json_value
+from harness_evals.utils.json_output import json_parse_failure_reason, parse_json_value
 
 
 @pytest.mark.unit
@@ -14,11 +14,24 @@ class TestParseJsonValue:
         assert parse_json_value('```json\n{"a": 1}\n```') == {"a": 1}
 
     def test_fenced_array(self):
-        assert parse_json_value('```\n[1, 2]\n```') == [1, 2]
+        assert parse_json_value("```\n[1, 2]\n```") == [1, 2]
 
     def test_passthrough_dict(self):
         assert parse_json_value({"x": 1}) == {"x": 1}
 
     def test_prose_before_fenced_object(self):
-        text = "Here is the JSON:\n```json\n{\"a\": 1}\n```"
+        text = 'Here is the JSON:\n```json\n{"a": 1}\n```'
         assert parse_json_value(text) == {"a": 1}
+
+    def test_garbage_returns_none(self):
+        assert parse_json_value("not json at all") is None
+
+    def test_garbage_failure_reason(self):
+        assert "no JSON object or array found" in json_parse_failure_reason("not json at all")
+
+    def test_invalid_fenced_json_returns_none(self):
+        assert parse_json_value("```json\n{broken\n```") is None
+
+    def test_invalid_fenced_json_failure_reason(self):
+        reason = json_parse_failure_reason("```json\n{broken\n```")
+        assert "Expecting" in reason or "could not decode" in reason


### PR DESCRIPTION
## Summary

- Add `parse_json_value()` in `harness_evals.utils.json_output` so `schema_validation` accepts markdown-fenced JSON and prose-wrapped model output (not only raw `json.loads` on the full string).
- Include parse-failure detail via `json_parse_failure_reason()` in metric `reason` strings.
- Tests cover fenced objects/arrays, leading prose, schema failures vs parse failures, and invalid output.

## Why this change (AIT-NL testgen evals)

In **[ait-nl-test-generation](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/default/projects/AI/repos/ait-nl-test-generation/summary/refs/heads/main)** we run testgen evals (`evals/testgen.eval.yaml`) against crawl-surface fixtures: the model must return structured `{ feature_map, test_cases }` JSON for `PromptTarget` runs ([findings doc](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/default/projects/AI/repos/ait-nl-test-generation/files/refs/heads/main/~/evals/findings/phase2-testgen.md)).

**What we hit:** With the built-in `kind: schema_validation` metric, eval runs failed even when the model returned **schema-valid** payloads. Claude Sonnet routinely wraps JSON in markdown fences:

````markdown
```json
{ "feature_map": [...], "test_cases": [...] }
```
````

The metric called `json.loads()` on the **entire** output string, so parse failed and every case scored 0 with a generic parse error — while our production testgen path and a temporary custom metric (`testgen_schema` + `json_parse_utils.py`) already strip fences and surrounding prose.

**Impact:** Deterministic schema gating was unusable out of the box for this eval; we had to fork behavior in-repo instead of relying on the SDK metric. That’s unnecessary friction for any PromptTarget / structured-output eval where fenced JSON is normal.

**After this PR:** Switch testgen evals to built-in `schema_validation` and remove the `testgen_schema` plugin (other metrics may still use shared parse helpers until consolidated).

## Local validation (AIT-NL dogfood)

Validated end-to-end before merge using an **editable install** of this branch (`pip install -e` from `fix/schema-validation-markdown-fences`) in the ait-nl eval venv — no PyPI release required for local testing.

In **ait-nl-test-generation**, `evals/testgen.eval.yaml` was updated to use built-in `kind: schema_validation` (same JSON Schema as the custom plugin) instead of `testgen_schema`, then:

```bash
cd ait-nl-test-generation
PYTHONPATH=. harness-evals run evals/testgen.eval.yaml
```

**Result (exit code 0, 3 golden cases, Sonnet target):**

| Metric | Pass rate | Mean |
|--------|-----------|------|
| `schema_validation` | **3/3 (100%)** | 1.00 |
| `grounding_validity` | 3/3 | 1.00 |
| `feature_alignment` | 3/3 | 1.00 |
| `geval` | 3/3 | 0.93 |
| **Overall quality** | **100%** | — |

Per-case `schema_validation` reason: *“Output conforms to the expected JSON Schema”*. This confirms fenced model output parses and validates with the built-in metric on real testgen runs.

## Test plan

- [x] `pytest tests/metrics/test_structural.py tests/utils/test_json_output.py -v`
- [x] `ruff check` / `ruff format --check` on touched files
- [x] AIT-NL `evals/testgen.eval.yaml` with built-in `schema_validation` (local editable SDK)
