### PR TITLE
feat: emit golden tags and id in JSONL result records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to harness-evals will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.7]
+
+### Added
+
+- **JSONL result identity**: `JsonSink` now writes top-level `tags` and `id` (from
+  `metadata.golden_id`) on every result record so CI/reporting can group failures by
+  golden tags without parsing IDs.
+- **`EvalCase.from_golden`**: copies `Golden.id` into `metadata.golden_id` when set.
+
 ## [0.19.6]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harness-evals"
-version = "0.19.6"
+version = "0.19.7"
 description = "Open-source AI evaluation framework for LLM agents, prompts, and structured outputs"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/harness_evals/core/eval_case.py
+++ b/src/harness_evals/core/eval_case.py
@@ -146,6 +146,11 @@ class EvalCase:
             merged_meta = {**(golden.metadata or {}), **(metadata_extra or {})}
         else:
             merged_meta = None
+        if golden.id:
+            if merged_meta is None:
+                merged_meta = {"golden_id": golden.id}
+            else:
+                merged_meta.setdefault("golden_id", golden.id)
         return cls(
             input=golden.input,
             output=output,

--- a/src/harness_evals/sinks/json_sink.py
+++ b/src/harness_evals/sinks/json_sink.py
@@ -110,6 +110,19 @@ def _messages_for_json(messages: list[dict[str, Any]] | None) -> list[dict[str, 
     return cleaned
 
 
+def _record_identity(eval_case: EvalCase) -> dict[str, Any]:
+    """Stable case id and golden tags for downstream reporting (CI, Slack, dashboards)."""
+    identity: dict[str, Any] = {}
+    if eval_case.tags:
+        identity["tags"] = dict(eval_case.tags)
+    metadata = eval_case.metadata
+    if isinstance(metadata, dict):
+        record_id = metadata.get("golden_id") or metadata.get("id")
+        if record_id:
+            identity["id"] = record_id
+    return identity
+
+
 def _debug_metadata(metadata: dict[str, Any] | None, messages: list[dict[str, Any]] | None) -> dict[str, Any]:
     """Small eval-run context for debugging; golden config (sse_checks) stays in the dataset."""
     debug: dict[str, Any] = {}
@@ -201,6 +214,7 @@ class JsonSink(BaseSink):
             "input": eval_case.input,
             "scores": [s.to_dict() for s in scores],
         }
+        record.update(_record_identity(eval_case))
         if self.include_eval_case:
             if self.omit_messages:
                 record["output"] = eval_case.output

--- a/tests/sinks/test_sinks.py
+++ b/tests/sinks/test_sinks.py
@@ -200,6 +200,22 @@ class TestJsonSink:
         assert len(record["scores"]) == 2
         assert record["scores"][0]["name"] == "exact_match"
 
+    def test_write_includes_id_and_tags(self, tmp_path, scores):
+        path = tmp_path / "results.jsonl"
+        eval_case = EvalCase(
+            input="List pipelines",
+            output="Found 3 pipelines",
+            tags={"module": "cd", "scenario_type": "read_only"},
+            metadata={"golden_id": "golden-abc-list-pipelines"},
+        )
+        sink = JsonSink(str(path))
+
+        sink.write(scores, eval_case)
+
+        record = json.loads(path.read_text().strip())
+        assert record["id"] == "golden-abc-list-pipelines"
+        assert record["tags"] == {"module": "cd", "scenario_type": "read_only"}
+
     def test_write_appends(self, tmp_path, eval_case, scores):
         path = tmp_path / "results.jsonl"
         sink = JsonSink(str(path))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -278,6 +278,16 @@ class TestAEvaluateTokenCapture:
         ec = EvalCase.from_golden(g, output="a")
         assert ec.metadata is None
 
+    def test_from_golden_copies_golden_id_to_metadata(self):
+        g = Golden(input="q", expected="a", id="my-golden-id")
+        ec = EvalCase.from_golden(g, output="a")
+        assert ec.metadata == {"golden_id": "my-golden-id"}
+
+    def test_from_golden_preserves_existing_golden_id_in_metadata(self):
+        g = Golden(input="q", expected="a", id="golden-id", metadata={"golden_id": "existing"})
+        ec = EvalCase.from_golden(g, output="a")
+        assert ec.metadata["golden_id"] == "existing"
+
     def test_from_golden_copies_expected_tools(self):
         g = Golden(input="q", expected="a", expected_tools=["search", "read"])
         ec = EvalCase.from_golden(g, output="a")


### PR DESCRIPTION
## Summary
- `JsonSink` writes top-level `tags` and `id` on every JSONL result record so CI/reporting can group failures by golden module tag without parsing IDs.
- `EvalCase.from_golden` copies `Golden.id` into `metadata.golden_id` when set.
- Bumps version to **0.19.7**.

## Motivation
The `runHarnessAiEvals` CI pipeline posts Slack notifications grouped by `tags.module`. Result JSONL previously omitted tags, forcing fragile golden-id prefix heuristics.

## Test plan
- [x] `pytest tests/sinks/test_sinks.py::TestJsonSink::test_write_includes_id_and_tags`
- [x] `pytest tests/test_core.py -k "from_golden_copies_golden_id or from_golden_preserves"`
- [ ] Merge and publish 0.19.7; update `HARNESS_EVALS_REF` in qpe-evals-library pipeline


Made with [Cursor](https://cursor.com)